### PR TITLE
chore(pkg): slim npm tarball from 1.3 MB to 19 kB

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ English | [简体中文](README.zh-CN.md)
 
 Learn a foreign language while you code. A [pi](https://pi.dev) extension that reviews your prompts for spelling, grammar, and natural phrasing — with explanations in your native language — and renders agent replies as bilingual immersive translations.
 
-<img src="docs/writing-check.png" width="720" alt="The Writing check panel: while the agent works on the prompt, each mistake is shown with its fix, an explanation in your native language, and a more natural phrasing of the whole sentence.">
+<img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/writing-check.png" width="720" alt="The Writing check panel: while the agent works on the prompt, each mistake is shown with its fix, an explanation in your native language, and a more natural phrasing of the whole sentence.">
 
 *You prompt with mistakes, the agent works anyway — and the `✏ Writing check` panel explains each fix in your native language.*
 
@@ -46,7 +46,7 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 2. When the agent finishes, press `alt+t` (macOS: ⌥T — [enable Option-as-Meta](https://iterm2.com/documentation-preferences-profiles-keys.html) in your terminal, or run `/translate`). The response re-renders as a bilingual card: each paragraph followed by its translation.
 
-   <img src="docs/bilingual-card.png" width="720" alt="The bilingual card: each paragraph of the agent's response is followed by its translation, immersive-translate style, with code blocks kept intact.">
+   <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/bilingual-card.png" width="720" alt="The bilingual card: each paragraph of the agent's response is followed by its translation, immersive-translate style, with code blocks kept intact.">
 
 3. Like the bilingual view? Make it automatic:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 一边 coding 一边学外语。这是一个 [pi](https://pi.dev) 扩展：它会检查你 prompt 里的拼写和语法，用母语给你讲解错在哪，还能把 agent 的回复渲染成沉浸式翻译那样的双语对照。
 
-<img src="docs/writing-check.png" width="720" alt="Writing check 面板：agent 照常处理 prompt 的同时，每个错误都给出改法、中文解释，以及整句更地道的说法。">
+<img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/writing-check.png" width="720" alt="Writing check 面板：agent 照常处理 prompt 的同时，每个错误都给出改法、中文解释，以及整句更地道的说法。">
 
 ## 安装
 
@@ -44,7 +44,7 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 2. agent 回答完，按 `alt+t`（macOS 上是 ⌥T，需要在终端里[把 Option 设为 Meta 键](https://iterm2.com/documentation-preferences-profiles-keys.html)；也可以直接运行 `/translate`）。回复会重新渲染成双语卡片，每个原文段落下面紧跟译文。
 
-   <img src="docs/bilingual-card.png" width="720" alt="双语卡片：agent 回复的每个段落下面紧跟译文，沉浸式翻译风格，代码块原样保留。">
+   <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/bilingual-card.png" width="720" alt="双语卡片：agent 回复的每个段落下面紧跟译文，沉浸式翻译风格，代码块原样保留。">
 
 3. 觉得双语对照好用，可以让每条回复自动翻译：
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
 	"type": "module",
 	"license": "MIT",
 	"main": "language-learn.ts",
+	"files": [
+		"language-learn.ts",
+		"src"
+	],
 	"pi": {
 		"extensions": [
 			"./language-learn.ts"


### PR DESCRIPTION
The published tarball was 1.3 MB, almost all of it the two README screenshots (`docs/*.png`, ~1.37 MB combined); it also shipped `.github/workflows/publish.yml`, `test.mjs`, and `tsconfig.json`.

- Add a `files` whitelist: only `src/` and `language-learn.ts` (npm always includes `package.json`, READMEs, and LICENSE).
- Point README `<img>` tags at GitHub raw URLs — relative image paths never rendered on npmjs.com anyway, and `package.json#image` already used the raw URL.

`npm pack --dry-run`: 17 → 12 files, 1.3 MB → 18.9 kB (52.1 kB unpacked). No runtime files removed — pi loads `language-learn.ts` → `src/*` only.