### PR TITLE
ci: run typecheck and tests on every PR and push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - run: npm ci
+      - run: npm run check
+      - run: npm test
+      # lint / fmt:check land with the oxlint+oxfmt PR (#5); --if-present
+      # keeps this workflow green on branches that predate those scripts.
+      - run: npm run lint --if-present
+      - run: npm run fmt:check --if-present


### PR DESCRIPTION
## What & why

Adds `.github/workflows/ci.yml` running `npm ci` → `npm run check` → `npm test` on every pull request and push to `main`, with a concurrency group cancelling superseded runs. Until now these checks only ran on the release publish workflow and on maintainers' machines — AGENTS.md's verify-before-pushing rule had no enforcement on PRs.

`npm run lint` and `npm run fmt:check` are invoked with `--if-present`: those scripts land with the oxlint+oxfmt tooling PR (#5), so this workflow stays green on branches cut before #5 merges (including this one) and picks the scripts up automatically once it's in. Node version and step order mirror `publish.yml` (node 24).

## Verification

- The workflow runs on this PR itself — see the checks on this page (check + test on `main`'s scripts, lint/fmt skipped via `--if-present`).
- After merging, consider marking the `checks` job as a required status check in branch protection so `BLOCKED` PRs actually wait on it.