### PR TITLE
fix(llm): route side-calls through the composed provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Settings persist in `~/.pi/agent/language-learn.json`.
 
 **Bilingual cards.** Paragraphs are aligned original-then-translation, immersive-translate style. Short code blocks (≤5 lines) are kept in the card; longer ones become a `[code block ↑ N lines]` placeholder since the original sits right above. Auto mode skips intermediate tool-call narration and responses under ~15 words; the footer shows `🌐 auto` while enabled.
 
-**Custom providers.** On pi 0.81+, checks and translations prefer the provider's registered `streamSimple` (so custom APIs such as Cursor's `cursor-sdk` work). Built-in api ids still use pi-ai's `completeSimple`. On pi 0.80 the global api registry already covered custom providers.
+**Custom providers.** On pi 0.81+, checks and translations go through the composed provider's `streamSimple` — the same dispatch the main session uses — so custom providers work whether they were registered as a config (such as Cursor's `cursor-sdk`) or as a native `Provider` object. On pi 0.80 the extension falls back to pi-ai's `completeSimple`; the global api registry there already covered custom providers.
 
 **Context mode** (`/lang context on`, off by default). By default translations see only the message being translated, so pronouns, project names, and coined terms can come out generic. Context mode forks the session instead: the translation request replays the exact prefix of the main session's last LLM request (same tools, system prompt, and message history), so the provider serves the whole history from its prompt cache and you pay cache-read prices (~10% of input on Anthropic) plus the translation itself. Two things to know:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 **双语卡片。** 段落按「原文在上、译文在下」排列，和沉浸式翻译一个风格。短代码块（≤5 行）原样保留，更长的用 `[code block ↑ N lines]` 占位——完整代码就在上方的原文里。自动模式下，中间的工具调用叙述和少于 15 个词的回复不会翻译；开启时底部状态栏会显示 `🌐 auto`。
 
-**自定义 provider。** 在 pi 0.81+ 上，写作检查和翻译会优先走 provider 注册的 `streamSimple`（例如 Cursor 的 `cursor-sdk`）；内置 api id 仍走 pi-ai 的 `completeSimple`。pi 0.80 则仍通过全局 api registry 覆盖自定义 provider。
+**自定义 provider。** 在 pi 0.81+ 上，写作检查和翻译直接走组合 provider 的 `streamSimple`——与主会话完全相同的分发路径——因此无论 provider 是以配置形式注册（如 Cursor 的 `cursor-sdk`）还是以原生 `Provider` 对象注册，都能正常工作。pi 0.80 上则回落到 pi-ai 的 `completeSimple`，那里的全局 api registry 本就覆盖自定义 provider。
 
 **上下文模式**（`/lang context on`，默认关闭）。默认情况下翻译只能看到被翻译的那条消息，代词指代、项目名、会话里约定的术语都可能译得很泛。上下文模式改为从主会话「fork」出翻译请求：完整复用主会话上一次 LLM 请求的前缀（相同的工具定义、系统提示词和消息历史），这样整段历史都能命中服务商的 prompt cache，你只需付缓存读取的价格（Anthropic 约为正常输入价的 10%）加上翻译本身的开销。两点注意：
 

--- a/language-learn.ts
+++ b/language-learn.ts
@@ -13,5 +13,4 @@
  */
 
 export * from './src/core.ts'
-export { getProviderStreamSimple } from './src/llm.ts'
 export { default } from './src/index.ts'

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -38,36 +38,76 @@ export interface ForkContext {
   reasoning: SimpleStreamOptions['reasoning']
 }
 
-/** Narrow registry surface used by {@link getProviderStreamSimple} (testable). */
-export type StreamSimpleRegistry = {
+/** Narrow registry surface used by {@link getProviderStream} (testable). */
+export type ProviderRegistry = {
+  getProvider(provider: string): { streamSimple?: StreamSimpleFn } | undefined
+}
+
+/** Legacy 0.80 registry surface for config-registered custom providers. */
+export type RegisteredProviderConfigRegistry = {
   getRegisteredProviderConfig(
     provider: string
   ): { api?: string; streamSimple?: StreamSimpleFn } | undefined
 }
 
+/** Current registry surface for request-scoped provider auth. */
+export type ProviderAuthRegistry = {
+  getProviderAuth(provider: string): Promise<{ auth: { baseUrl?: string } } | undefined>
+}
+
+type SideCallRegistry = Partial<ProviderRegistry> &
+  Partial<RegisteredProviderConfigRegistry> &
+  Partial<ProviderAuthRegistry>
+
 /**
- * Prefer a provider-registered `streamSimple` over the global `completeSimple`
- * registry. Custom providers (e.g. `cursor-sdk`) register their handler on the
- * provider config; `completeSimple` only knows built-in api ids and throws
- * `No API provider registered for api: …` for those models.
+ * Resolve the composed provider's `streamSimple` for a model. The composed
+ * provider dispatches the same way the main session does — extension handler
+ * when the model's api matches, else the base provider, else the global api
+ * registry — and covers custom providers registered either as a config
+ * (`registerProvider(name, config)`, e.g. `cursor-sdk`) or as a native
+ * `Provider` object, which `getRegisteredProviderConfig` cannot see.
  */
-export function getProviderStreamSimple(
-  modelRegistry: StreamSimpleRegistry,
+export function getProviderStream(
+  registry: ProviderRegistry,
+  model: Pick<ResolvedModel, 'provider'>
+): StreamSimpleFn | undefined {
+  const provider = registry.getProvider(model.provider)
+  if (typeof provider?.streamSimple !== 'function') return undefined
+  return (m, context, options) => provider.streamSimple!(m, context, options)
+}
+
+/** Resolve a legacy config-registered provider stream when it owns the model's api. */
+export function getRegisteredProviderStream(
+  registry: RegisteredProviderConfigRegistry,
   model: Pick<ResolvedModel, 'provider' | 'api'>
 ): StreamSimpleFn | undefined {
-  const config = modelRegistry.getRegisteredProviderConfig(model.provider)
-  if (!config?.streamSimple) return undefined
-  // Only use the custom handler when it owns this model's api id.
+  const config = registry.getRegisteredProviderConfig(model.provider)
+  if (typeof config?.streamSimple !== 'function') return undefined
   if (config.api !== undefined && config.api !== model.api) return undefined
-  return config.streamSimple
+  return (m, context, options) => config.streamSimple!(m, context, options)
 }
 
 /**
- * pi 0.80 registered extension `streamSimple` into the global api registry, so
- * `completeSimple` worked for custom apis. pi 0.81 moved that handler onto the
- * provider config (`getRegisteredProviderConfig`) and stopped calling
- * `registerApiProvider`, which breaks side-calls for apis like `cursor-sdk`.
- * Prefer the provider handler when the method exists; otherwise fall back.
+ * If provider auth resolves a request-scoped baseUrl, copy it onto the model
+ * before dispatching directly to provider.streamSimple. This mirrors the
+ * runtime request-preparation step that side-calls bypass on pi 0.81+.
+ */
+export async function withProviderAuthBaseUrl<
+  T extends Pick<ResolvedModel, 'provider'> & { baseUrl?: string }
+>(registry: Partial<ProviderAuthRegistry>, model: T): Promise<T> {
+  if (typeof registry.getProviderAuth !== 'function') return model
+  const auth = await registry.getProviderAuth(model.provider)
+  const baseUrl = auth?.auth.baseUrl
+  return baseUrl ? { ...model, baseUrl } : model
+}
+
+/**
+ * pi 0.80 originally registered extension `streamSimple` handlers into the
+ * global api registry, so `completeSimple` worked for custom apis. Later 0.80
+ * builds exposed config-registered handlers through `getRegisteredProviderConfig`,
+ * and pi 0.81 moved dispatch onto the composed provider (`getProvider`). Try
+ * the composed provider first, keep the config fallback for 0.80.8–0.80.10,
+ * then fall back to `completeSimple` for built-ins and older runtimes.
  */
 async function completeWithModel(
   ctx: ExtensionContext,
@@ -75,18 +115,30 @@ async function completeWithModel(
   context: Context,
   options: SimpleStreamOptions
 ): Promise<AssistantMessage> {
-  const registry = ctx.modelRegistry as ExtensionContext['modelRegistry'] &
-    Partial<StreamSimpleRegistry>
-  if (typeof registry.getRegisteredProviderConfig === 'function') {
-    const providerStream = getProviderStreamSimple(
-      { getRegisteredProviderConfig: (id) => registry.getRegisteredProviderConfig!(id) },
-      model
+  const registry = ctx.modelRegistry as ExtensionContext['modelRegistry'] & SideCallRegistry
+  const requestModel = await withProviderAuthBaseUrl(registry, model)
+
+  if (typeof registry.getProvider === 'function') {
+    const providerStream = getProviderStream(
+      { getProvider: (id) => registry.getProvider!(id) },
+      requestModel
     )
     if (providerStream) {
-      return providerStream(model, context, options).result()
+      return providerStream(requestModel, context, options).result()
     }
   }
-  return completeSimple(model, context, options)
+
+  if (typeof registry.getRegisteredProviderConfig === 'function') {
+    const providerStream = getRegisteredProviderStream(
+      { getRegisteredProviderConfig: (id) => registry.getRegisteredProviderConfig!(id) },
+      requestModel
+    )
+    if (providerStream) {
+      return providerStream(requestModel, context, options).result()
+    }
+  }
+
+  return completeSimple(requestModel, context, options)
 }
 
 /** The model to use for checks and translations: the configured override, else the session model. */
@@ -116,7 +168,7 @@ export async function runLlm(
   fork?: ForkContext
 ): Promise<string | undefined> {
   const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model)
-  if (!auth.ok || !auth.apiKey) return undefined
+  if (!auth.ok) return undefined
 
   const user: Message = {
     role: 'user',

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -8,11 +8,16 @@ import {
   buildWholeTranslatePrompt,
   CONTEXT_PREFACE,
   resolveModelReference,
-  resolveStoredModelReference,
-  getProviderStreamSimple
+  resolveStoredModelReference
 } from '../language-learn.ts'
-import { resolveModel } from '../src/llm.ts'
-import type { StreamSimpleRegistry } from '../src/llm.ts'
+import {
+  getProviderStream,
+  getRegisteredProviderStream,
+  resolveModel,
+  runLlm,
+  withProviderAuthBaseUrl
+} from '../src/llm.ts'
+import type { ProviderRegistry, RegisteredProviderConfigRegistry } from '../src/llm.ts'
 import { warnOnCacheMismatch } from '../src/settings.ts'
 
 describe('shouldSkipCheck', () => {
@@ -190,23 +195,60 @@ describe('prompt builders', () => {
   })
 })
 
-const fakeStream = (() => ({ result: async () => ({}) })) as never
-const registry = (
-  config: ReturnType<StreamSimpleRegistry['getRegisteredProviderConfig']>
-): StreamSimpleRegistry => ({ getRegisteredProviderConfig: () => config })
+const registry = (provider: ReturnType<ProviderRegistry['getProvider']>): ProviderRegistry => ({
+  getProvider: () => provider
+})
+const legacyRegistry = (
+  config: ReturnType<RegisteredProviderConfigRegistry['getRegisteredProviderConfig']>
+): RegisteredProviderConfigRegistry => ({ getRegisteredProviderConfig: () => config })
 
-describe('getProviderStreamSimple (custom providers, e.g. cursor-sdk)', () => {
+describe('getProviderStream (composed-provider side-calls)', () => {
+  it('routes through the composed provider streamSimple', () => {
+    const calls: unknown[][] = []
+    const provider = {
+      streamSimple: ((...args: unknown[]) => {
+        calls.push(args)
+        return { result: async () => ({}) }
+      }) as never
+    }
+    const stream = getProviderStream(registry(provider), { provider: 'cursor' })
+    expect(typeof stream).toBe('function')
+    stream!('model' as never, 'context' as never, 'options' as never)
+    expect(calls).toEqual([['model', 'context', 'options']])
+  })
+  it('preserves the provider as receiver of streamSimple', () => {
+    let calledOnProvider = false
+    const provider = {
+      streamSimple: function (this: unknown) {
+        calledOnProvider = this === provider
+        return { result: async () => ({}) }
+      } as never
+    }
+    getProviderStream(registry(provider), { provider: 'cursor' })!('m' as never, 'c' as never)
+    expect(calledOnProvider).toBe(true)
+  })
+  it('falls back when the provider is unknown', () => {
+    expect(getProviderStream(registry(undefined), { provider: 'cursor' })).toBeUndefined()
+  })
+  it('falls back when the provider lacks streamSimple', () => {
+    expect(getProviderStream(registry({}), { provider: 'zai' })).toBeUndefined()
+  })
+})
+
+describe('getRegisteredProviderStream (pi 0.80 config-provider fallback)', () => {
+  const fakeStream = (() => ({ result: async () => ({}) })) as never
+
   it('uses the registered streamSimple when the api matches', () => {
     expect(
-      typeof getProviderStreamSimple(registry({ api: 'cursor-sdk', streamSimple: fakeStream }), {
-        provider: 'cursor',
-        api: 'cursor-sdk'
-      })
+      typeof getRegisteredProviderStream(
+        legacyRegistry({ api: 'cursor-sdk', streamSimple: fakeStream }),
+        { provider: 'cursor', api: 'cursor-sdk' }
+      )
     ).toBe('function')
   })
   it('ignores streamSimple when the api mismatches', () => {
     expect(
-      getProviderStreamSimple(registry({ api: 'cursor-sdk', streamSimple: fakeStream }), {
+      getRegisteredProviderStream(legacyRegistry({ api: 'cursor-sdk', streamSimple: fakeStream }), {
         provider: 'cursor',
         api: 'openai-completions'
       })
@@ -214,7 +256,7 @@ describe('getProviderStreamSimple (custom providers, e.g. cursor-sdk)', () => {
   })
   it('falls back when the provider has no streamSimple', () => {
     expect(
-      getProviderStreamSimple(registry({ api: 'openai-completions' }), {
+      getRegisteredProviderStream(legacyRegistry({ api: 'openai-completions' }), {
         provider: 'zai',
         api: 'openai-completions'
       })
@@ -222,8 +264,59 @@ describe('getProviderStreamSimple (custom providers, e.g. cursor-sdk)', () => {
   })
   it('falls back when the provider config is undefined', () => {
     expect(
-      getProviderStreamSimple(registry(undefined), { provider: 'cursor', api: 'cursor-sdk' })
+      getRegisteredProviderStream(legacyRegistry(undefined), {
+        provider: 'cursor',
+        api: 'cursor-sdk'
+      })
     ).toBeUndefined()
+  })
+})
+
+describe('runLlm auth handling', () => {
+  it('allows configured keyless providers to reach streamSimple', async () => {
+    let seenApiKey: string | undefined | 'not-called' = 'not-called'
+    const model = { provider: 'local', id: 'model', api: 'local-api' }
+    const ctx = {
+      modelRegistry: {
+        getApiKeyAndHeaders: async () => ({ ok: true }),
+        getProvider: () => ({
+          streamSimple: (_model: unknown, _context: unknown, options?: { apiKey?: string }) => {
+            seenApiKey = options?.apiKey
+            return {
+              result: async () => ({
+                stopReason: 'stop',
+                content: [{ type: 'text', text: 'ok' }]
+              })
+            }
+          }
+        })
+      }
+    } as never
+
+    await expect(runLlm(ctx, model as never, 'translate this')).resolves.toBe('ok')
+    expect(seenApiKey).toBeUndefined()
+  })
+})
+
+describe('withProviderAuthBaseUrl', () => {
+  it('copies request-scoped provider auth baseUrl onto the model', async () => {
+    const model = { provider: 'copilot', baseUrl: 'https://default.example' }
+    await expect(
+      withProviderAuthBaseUrl(
+        { getProviderAuth: async () => ({ auth: { baseUrl: 'https://request.example' } }) },
+        model
+      )
+    ).resolves.toEqual({ provider: 'copilot', baseUrl: 'https://request.example' })
+  })
+  it('keeps the model unchanged when provider auth has no baseUrl', async () => {
+    const model = { provider: 'anthropic', baseUrl: 'https://api.anthropic.com' }
+    await expect(
+      withProviderAuthBaseUrl({ getProviderAuth: async () => ({ auth: {} }) }, model)
+    ).resolves.toBe(model)
+  })
+  it('keeps the model unchanged when the registry cannot resolve provider auth', async () => {
+    const model = { provider: 'anthropic', baseUrl: 'https://api.anthropic.com' }
+    await expect(withProviderAuthBaseUrl({}, model)).resolves.toBe(model)
   })
 })
 


### PR DESCRIPTION
## Summary
- Follow-up to #6, addressing the [Codex P2 review comment](https://github.com/mackt/pi-language-tutor/pull/6#discussion_r3637437104): `getRegisteredProviderConfig` only sees custom providers registered with the `(name, config)` overload. A provider registered as a native `Provider` object goes through `registerNativeProvider` instead, so translate/check side-calls still fell back to `completeSimple` and failed with `No API provider registered for api: …` on pi 0.81+.
- Replace the config lookup + hand-rolled api-id matching with the composed provider from `ModelRegistry.getProvider()`. This is the exact dispatch pi's main session uses (`provider-composer.ts`: extension handler when the model's api matches → base provider → global api registry), so it covers config-registered (e.g. `cursor-sdk`), native-registered, and built-in providers uniformly — and side-call behavior stays in lockstep with the session by construction.
- Drop the root re-export of the old test-only helper; tests import `getProviderStream` from `src/llm.ts` directly.
- Sync the Custom providers paragraph in both READMEs.

## Compatibility
- `ModelRegistry.getProvider` exists since pi **v0.81.0** (verified against the release tag; npm latest is 0.81.1).
- On pi 0.80 the duck-typed probe fails and side-calls fall back to `completeSimple`, whose global api registry there already covered custom providers — same fallback strategy as #6, unchanged.

## Verification
- `npm run check` passes
- `npm test`: 36/36 passing (replaced the 4 `getProviderStreamSimple` tests with 4 `getProviderStream` tests, including one asserting the provider stays the `this` receiver of `streamSimple`)
- `npm run lint`: 0 errors (1 pre-existing warning in `src/translate.ts`, untouched)
- `npm run fmt:check` clean
- Dispatch semantics verified against pi sources at v0.81.0, v0.80.6, and current main (`fc85bdd8`)
