### PR TITLE
fix(settings): accept bare model ids in /lang model like pi does

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,17 @@ That is enough to start.
 
 Type `/lang` in the TUI to open the interactive settings menu, or set things directly with the commands below.
 
-| Command                     | What it does                                                                                                                                             |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/translate` or `alt+t`     | Translate the last assistant response (bilingual card)                                                                                                   |
-| `/lang`                     | Open the interactive settings menu — every option with an inline description                                                                             |
-| `/lang on` \| `off`         | Resume / pause the writing check                                                                                                                         |
-| `/lang auto on` \| `off`    | Auto-translate every final response                                                                                                                      |
-| `/lang native <code>`       | Set your native language — translation target and explanation language (`zh-CN`, `ja`, …)                                                                |
-| `/lang learning <code>`     | Set the language you are practicing (`en`, `fr`, …)                                                                                                      |
-| `/lang model <model>`       | Use a cheaper model for checks and translations — `provider/id`, or just the model id when it is unique among the providers you have configured auth for |
-| `/lang model default`       | Go back to the session model                                                                                                                             |
-| `/lang context on` \| `off` | Give translations the full session context (off by default; see below)                                                                                   |
+| Command                     | What it does                                                                              |
+| --------------------------- | ----------------------------------------------------------------------------------------- |
+| `/translate` or `alt+t`     | Translate the last assistant response (bilingual card)                                    |
+| `/lang`                     | Open the interactive settings menu — every option with an inline description              |
+| `/lang on` \| `off`         | Resume / pause the writing check                                                          |
+| `/lang auto on` \| `off`    | Auto-translate every final response                                                       |
+| `/lang native <code>`       | Set your native language — translation target and explanation language (`zh-CN`, `ja`, …) |
+| `/lang learning <code>`     | Set the language you are practicing (`en`, `fr`, …)                                       |
+| `/lang model [model]`       | Set the model this extension uses                                                         |
+| `/lang model default`       | Go back to the session model                                                              |
+| `/lang context on` \| `off` | Give translations the full session context (off by default; see below)                    |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -66,17 +66,17 @@ That is enough to start.
 
 Type `/lang` in the TUI to open the interactive settings menu, or set things directly with the commands below.
 
-| Command                     | What it does                                                                                                             |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `/translate` or `alt+t`     | Translate the last assistant response (bilingual card)                                                                   |
-| `/lang`                     | Open the interactive settings menu — every option with an inline description                                             |
-| `/lang on` \| `off`         | Resume / pause the writing check                                                                                         |
-| `/lang auto on` \| `off`    | Auto-translate every final response                                                                                      |
-| `/lang native <code>`       | Set your native language — translation target and explanation language (`zh-CN`, `ja`, …)                                |
-| `/lang learning <code>`     | Set the language you are practicing (`en`, `fr`, …)                                                                      |
-| `/lang model <model>`       | Use a cheaper model for checks and translations — `provider/id`, or just the model id when it is unique across providers |
-| `/lang model default`       | Go back to the session model                                                                                             |
-| `/lang context on` \| `off` | Give translations the full session context (off by default; see below)                                                   |
+| Command                     | What it does                                                                                                                                             |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/translate` or `alt+t`     | Translate the last assistant response (bilingual card)                                                                                                   |
+| `/lang`                     | Open the interactive settings menu — every option with an inline description                                                                             |
+| `/lang on` \| `off`         | Resume / pause the writing check                                                                                                                         |
+| `/lang auto on` \| `off`    | Auto-translate every final response                                                                                                                      |
+| `/lang native <code>`       | Set your native language — translation target and explanation language (`zh-CN`, `ja`, …)                                                                |
+| `/lang learning <code>`     | Set the language you are practicing (`en`, `fr`, …)                                                                                                      |
+| `/lang model <model>`       | Use a cheaper model for checks and translations — `provider/id`, or just the model id when it is unique among the providers you have configured auth for |
+| `/lang model default`       | Go back to the session model                                                                                                                             |
+| `/lang context on` \| `off` | Give translations the full session context (off by default; see below)                                                                                   |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -66,17 +66,17 @@ That is enough to start.
 
 Type `/lang` in the TUI to open the interactive settings menu, or set things directly with the commands below.
 
-| Command                     | What it does                                                                              |
-| --------------------------- | ----------------------------------------------------------------------------------------- |
-| `/translate` or `alt+t`     | Translate the last assistant response (bilingual card)                                    |
-| `/lang`                     | Open the interactive settings menu — every option with an inline description              |
-| `/lang on` \| `off`         | Resume / pause the writing check                                                          |
-| `/lang auto on` \| `off`    | Auto-translate every final response                                                       |
-| `/lang native <code>`       | Set your native language — translation target and explanation language (`zh-CN`, `ja`, …) |
-| `/lang learning <code>`     | Set the language you are practicing (`en`, `fr`, …)                                       |
-| `/lang model <provider/id>` | Use a cheaper model for checks and translations                                           |
-| `/lang model default`       | Go back to the session model                                                              |
-| `/lang context on` \| `off` | Give translations the full session context (off by default; see below)                    |
+| Command                     | What it does                                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `/translate` or `alt+t`     | Translate the last assistant response (bilingual card)                                                                   |
+| `/lang`                     | Open the interactive settings menu — every option with an inline description                                             |
+| `/lang on` \| `off`         | Resume / pause the writing check                                                                                         |
+| `/lang auto on` \| `off`    | Auto-translate every final response                                                                                      |
+| `/lang native <code>`       | Set your native language — translation target and explanation language (`zh-CN`, `ja`, …)                                |
+| `/lang learning <code>`     | Set the language you are practicing (`en`, `fr`, …)                                                                      |
+| `/lang model <model>`       | Use a cheaper model for checks and translations — `provider/id`, or just the model id when it is unique across providers |
+| `/lang model default`       | Go back to the session model                                                                                             |
+| `/lang context on` \| `off` | Give translations the full session context (off by default; see below)                                                   |
 
 ## Configuration
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,17 +64,17 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 在 TUI 中输入 `/lang` 打开交互式设置菜单，也可以用下面的命令直接设置。
 
-| 命令                        | 作用                                                                          |
-| --------------------------- | ----------------------------------------------------------------------------- |
-| `/translate` 或 `alt+t`     | 翻译 agent 回复（双语卡片）                                                   |
-| `/lang`                     | 打开交互式设置菜单，每个选项都有一行说明                                      |
-| `/lang on` \| `off`         | 恢复/暂停写作检查                                                             |
-| `/lang auto on` \| `off`    | 自动翻译每轮最终回复                                                          |
-| `/lang native <code>`       | 设置母语，即译文和讲解使用的语言（`zh-CN`、`ja`…）                            |
-| `/lang learning <code>`     | 设置正在学习的语言（`en`、`fr`…）                                             |
-| `/lang model <model>`       | 用更便宜的模型跑检查和翻译——写 `provider/id`，模型 id 全局唯一时也可以只写 id |
-| `/lang model default`       | 换回会话模型                                                                  |
-| `/lang context on` \| `off` | 翻译时携带完整会话上下文（默认关闭，详见下文）                                |
+| 命令                        | 作用                                                                                                |
+| --------------------------- | --------------------------------------------------------------------------------------------------- |
+| `/translate` 或 `alt+t`     | 翻译 agent 回复（双语卡片）                                                                         |
+| `/lang`                     | 打开交互式设置菜单，每个选项都有一行说明                                                            |
+| `/lang on` \| `off`         | 恢复/暂停写作检查                                                                                   |
+| `/lang auto on` \| `off`    | 自动翻译每轮最终回复                                                                                |
+| `/lang native <code>`       | 设置母语，即译文和讲解使用的语言（`zh-CN`、`ja`…）                                                  |
+| `/lang learning <code>`     | 设置正在学习的语言（`en`、`fr`…）                                                                   |
+| `/lang model <model>`       | 用更便宜的模型跑检查和翻译——写 `provider/id`，模型 id 在已配置认证的 provider 中唯一时也可以只写 id |
+| `/lang model default`       | 换回会话模型                                                                                        |
+| `/lang context on` \| `off` | 翻译时携带完整会话上下文（默认关闭，详见下文）                                                      |
 
 ## 配置
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,17 +64,17 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 在 TUI 中输入 `/lang` 打开交互式设置菜单，也可以用下面的命令直接设置。
 
-| 命令                        | 作用                                                                                                |
-| --------------------------- | --------------------------------------------------------------------------------------------------- |
-| `/translate` 或 `alt+t`     | 翻译 agent 回复（双语卡片）                                                                         |
-| `/lang`                     | 打开交互式设置菜单，每个选项都有一行说明                                                            |
-| `/lang on` \| `off`         | 恢复/暂停写作检查                                                                                   |
-| `/lang auto on` \| `off`    | 自动翻译每轮最终回复                                                                                |
-| `/lang native <code>`       | 设置母语，即译文和讲解使用的语言（`zh-CN`、`ja`…）                                                  |
-| `/lang learning <code>`     | 设置正在学习的语言（`en`、`fr`…）                                                                   |
-| `/lang model <model>`       | 用更便宜的模型跑检查和翻译——写 `provider/id`，模型 id 在已配置认证的 provider 中唯一时也可以只写 id |
-| `/lang model default`       | 换回会话模型                                                                                        |
-| `/lang context on` \| `off` | 翻译时携带完整会话上下文（默认关闭，详见下文）                                                      |
+| 命令                        | 作用                                               |
+| --------------------------- | -------------------------------------------------- |
+| `/translate` 或 `alt+t`     | 翻译 agent 回复（双语卡片）                        |
+| `/lang`                     | 打开交互式设置菜单，每个选项都有一行说明           |
+| `/lang on` \| `off`         | 恢复/暂停写作检查                                  |
+| `/lang auto on` \| `off`    | 自动翻译每轮最终回复                               |
+| `/lang native <code>`       | 设置母语，即译文和讲解使用的语言（`zh-CN`、`ja`…） |
+| `/lang learning <code>`     | 设置正在学习的语言（`en`、`fr`…）                  |
+| `/lang model [model]`       | 指定本插件使用的模型                               |
+| `/lang model default`       | 换回会话模型                                       |
+| `/lang context on` \| `off` | 翻译时携带完整会话上下文（默认关闭，详见下文）     |
 
 ## 配置
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,17 +64,17 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 在 TUI 中输入 `/lang` 打开交互式设置菜单，也可以用下面的命令直接设置。
 
-| 命令                        | 作用                                               |
-| --------------------------- | -------------------------------------------------- |
-| `/translate` 或 `alt+t`     | 翻译 agent 回复（双语卡片）                        |
-| `/lang`                     | 打开交互式设置菜单，每个选项都有一行说明           |
-| `/lang on` \| `off`         | 恢复/暂停写作检查                                  |
-| `/lang auto on` \| `off`    | 自动翻译每轮最终回复                               |
-| `/lang native <code>`       | 设置母语，即译文和讲解使用的语言（`zh-CN`、`ja`…） |
-| `/lang learning <code>`     | 设置正在学习的语言（`en`、`fr`…）                  |
-| `/lang model <provider/id>` | 用更便宜的模型跑检查和翻译                         |
-| `/lang model default`       | 换回会话模型                                       |
-| `/lang context on` \| `off` | 翻译时携带完整会话上下文（默认关闭，详见下文）     |
+| 命令                        | 作用                                                                          |
+| --------------------------- | ----------------------------------------------------------------------------- |
+| `/translate` 或 `alt+t`     | 翻译 agent 回复（双语卡片）                                                   |
+| `/lang`                     | 打开交互式设置菜单，每个选项都有一行说明                                      |
+| `/lang on` \| `off`         | 恢复/暂停写作检查                                                             |
+| `/lang auto on` \| `off`    | 自动翻译每轮最终回复                                                          |
+| `/lang native <code>`       | 设置母语，即译文和讲解使用的语言（`zh-CN`、`ja`…）                            |
+| `/lang learning <code>`     | 设置正在学习的语言（`en`、`fr`…）                                             |
+| `/lang model <model>`       | 用更便宜的模型跑检查和翻译——写 `provider/id`，模型 id 全局唯一时也可以只写 id |
+| `/lang model default`       | 换回会话模型                                                                  |
+| `/lang context on` \| `off` | 翻译时携带完整会话上下文（默认关闭，详见下文）                                |
 
 ## 配置
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -308,9 +308,13 @@ export function resolveModelReference<M extends ModelRefLike>(
  * saved canonical `provider/id` is an already-disambiguated answer: restore
  * it exactly from the catalog — reporting `needsAuth` when its provider lost
  * auth, so side-calls fail visibly instead of being silently re-routed to an
- * authed provider whose raw id happens to spell the same. Only references
- * that match no canonical pair (hand-edited bare ids) fall back to the
- * interactive {@link resolveModelReference} semantics.
+ * authed provider whose raw id happens to spell the same. A ref whose prefix
+ * names a known provider but whose exact model left the catalog (dropped or
+ * renamed) resolves to nothing — the caller falls back to the session model —
+ * rather than raw-matching the string onto another provider's lookalike id.
+ * Only refs not interpretable as a provider choice (hand-edited bare ids, or
+ * raw ids whose prefix is no provider) fall back to the interactive
+ * {@link resolveModelReference} semantics.
  */
 export function resolveStoredModelReference<M extends ModelRefLike>(
   reference: string,
@@ -326,6 +330,11 @@ export function resolveStoredModelReference<M extends ModelRefLike>(
       (m) => m.provider === exact.model.provider && m.id === exact.model.id
     )
     return authed ? exact : { kind: 'needsAuth', model: exact.model }
+  }
+
+  const slash = ref.indexOf('/')
+  if (slash > 0 && catalog.some((m) => m.provider.toLowerCase() === ref.slice(0, slash))) {
+    return { kind: 'none' }
   }
 
   return resolveModelReference(reference, available, catalog)

--- a/src/core.ts
+++ b/src/core.ts
@@ -302,3 +302,31 @@ export function resolveModelReference<M extends ModelRefLike>(
   }
   return { kind: 'none' }
 }
+
+/**
+ * Resolve a reference persisted in the config. Unlike interactive input, a
+ * saved canonical `provider/id` is an already-disambiguated answer: restore
+ * it exactly from the catalog — reporting `needsAuth` when its provider lost
+ * auth, so side-calls fail visibly instead of being silently re-routed to an
+ * authed provider whose raw id happens to spell the same. Only references
+ * that match no canonical pair (hand-edited bare ids) fall back to the
+ * interactive {@link resolveModelReference} semantics.
+ */
+export function resolveStoredModelReference<M extends ModelRefLike>(
+  reference: string,
+  available: readonly M[],
+  catalog: readonly M[]
+): ModelResolution<M> {
+  const ref = reference.trim().toLowerCase()
+  if (!ref) return { kind: 'none' }
+
+  const exact = decide(catalog.filter((m) => `${m.provider}/${m.id}`.toLowerCase() === ref))
+  if (exact?.kind === 'found') {
+    const authed = available.some(
+      (m) => m.provider === exact.model.provider && m.id === exact.model.id
+    )
+    return authed ? exact : { kind: 'needsAuth', model: exact.model }
+  }
+
+  return resolveModelReference(reference, available, catalog)
+}

--- a/src/core.ts
+++ b/src/core.ts
@@ -225,45 +225,80 @@ export interface ModelRefLike {
   id: string
 }
 
-export type ModelMatch<M extends ModelRefLike> =
+export type ModelResolution<M extends ModelRefLike> =
+  /** Resolved to a model with configured auth. */
   | { kind: 'found'; model: M }
+  /** Resolved, but the model's provider has no configured auth. */
+  | { kind: 'needsAuth'; model: M }
+  /** Several configured-auth models match a bare id. */
   | { kind: 'ambiguous'; candidates: M[] }
+  /** Only unconfigured providers' catalogs list this bare id. */
+  | { kind: 'noAuthAnywhere'; candidates: M[] }
   | { kind: 'none' }
 
-function decide<M extends ModelRefLike>(matches: M[]): ModelMatch<M> | undefined {
+function decide<M extends ModelRefLike>(
+  matches: M[]
+): { kind: 'found'; model: M } | { kind: 'ambiguous'; candidates: M[] } | undefined {
   if (matches.length === 1) return { kind: 'found', model: matches[0] }
   if (matches.length > 1) return { kind: 'ambiguous', candidates: matches }
   return undefined
 }
 
 /**
- * Match a user-supplied model reference the way pi's own resolver does
- * (`core/model-resolver.ts`, not re-exported by the package): canonical
- * `provider/id` match first — which also handles model ids that themselves
- * contain slashes — then a first-slash split, then a bare model id. All
- * comparisons are case-insensitive. A bare id shared by several providers is
- * reported as ambiguous with the candidates, so callers can list them.
+ * Resolve a user-supplied model reference the way pi's CLI `-m` does
+ * (`core/model-resolver.ts`, not re-exported by the package):
+ *
+ * 1. When the prefix before the first slash names a known provider, prefer
+ *    the `provider/id` interpretation ("zai/glm-5" is zai's glm-5, not a
+ *    gateway model whose id is literally "zai/glm-5").
+ * 2. If that interpretation exists only without auth while exactly one
+ *    configured-auth model's raw id equals the whole reference, prefer the
+ *    authenticated one (ids like "xiaomi/mimo-v2.5-pro" where the prefix
+ *    happens to name a provider).
+ * 3. Otherwise fall back to matching the whole reference as a canonical
+ *    `provider/id` or a raw model id — OpenRouter-style ids keep working.
+ *
+ * All comparisons are case-insensitive. `available` is the configured-auth
+ * subset of `catalog`; pass the same list twice to resolve identity only.
  */
-export function matchModelReference<M extends ModelRefLike>(
+export function resolveModelReference<M extends ModelRefLike>(
   reference: string,
-  models: readonly M[]
-): ModelMatch<M> {
+  available: readonly M[],
+  catalog: readonly M[]
+): ModelResolution<M> {
   const ref = reference.trim().toLowerCase()
   if (!ref) return { kind: 'none' }
 
-  const canonical = decide(models.filter((m) => `${m.provider}/${m.id}`.toLowerCase() === ref))
-  if (canonical) return canonical
-
   const slash = ref.indexOf('/')
   if (slash > 0 && slash < ref.length - 1) {
-    // Trimmed separately so "provider / id" with stray spaces still resolves.
-    const provider = ref.slice(0, slash).trim()
-    const id = ref.slice(slash + 1).trim()
-    const split = decide(
-      models.filter((m) => m.provider.toLowerCase() === provider && m.id.toLowerCase() === id)
-    )
-    if (split) return split
+    const prefix = ref.slice(0, slash)
+    if (catalog.some((m) => m.provider.toLowerCase() === prefix)) {
+      const id = ref.slice(slash + 1)
+      const inProvider = (models: readonly M[]) =>
+        models.filter((m) => m.provider.toLowerCase() === prefix && m.id.toLowerCase() === id)
+      const availableHit = decide(inProvider(available))
+      if (availableHit) return availableHit
+      const catalogHit = decide(inProvider(catalog))
+      if (catalogHit?.kind === 'found') {
+        const rawMatches = available.filter((m) => m.id.toLowerCase() === ref)
+        if (rawMatches.length === 1) return { kind: 'found', model: rawMatches[0] }
+        return { kind: 'needsAuth', model: catalogHit.model }
+      }
+      // Known provider but no such model under it: fall through — the whole
+      // reference may still be a raw model id elsewhere.
+    }
   }
 
-  return decide(models.filter((m) => m.id.toLowerCase() === ref)) ?? { kind: 'none' }
+  const whole = (models: readonly M[]) =>
+    models.filter(
+      (m) => m.id.toLowerCase() === ref || `${m.provider}/${m.id}`.toLowerCase() === ref
+    )
+  const availableHit = decide(whole(available))
+  if (availableHit) return availableHit
+  const catalogHit = decide(whole(catalog))
+  if (catalogHit?.kind === 'found') return { kind: 'needsAuth', model: catalogHit.model }
+  if (catalogHit?.kind === 'ambiguous') {
+    return { kind: 'noAuthAnywhere', candidates: catalogHit.candidates }
+  }
+  return { kind: 'none' }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -218,3 +218,52 @@ export function cardMarkdown(segments: CardSegment[]): string {
     })
     .join('\n\n')
 }
+
+/** The subset of a registry model a reference can be matched against. */
+export interface ModelRefLike {
+  provider: string
+  id: string
+}
+
+export type ModelMatch<M extends ModelRefLike> =
+  | { kind: 'found'; model: M }
+  | { kind: 'ambiguous'; candidates: M[] }
+  | { kind: 'none' }
+
+function decide<M extends ModelRefLike>(matches: M[]): ModelMatch<M> | undefined {
+  if (matches.length === 1) return { kind: 'found', model: matches[0] }
+  if (matches.length > 1) return { kind: 'ambiguous', candidates: matches }
+  return undefined
+}
+
+/**
+ * Match a user-supplied model reference the way pi's own resolver does
+ * (`core/model-resolver.ts`, not re-exported by the package): canonical
+ * `provider/id` match first — which also handles model ids that themselves
+ * contain slashes — then a first-slash split, then a bare model id. All
+ * comparisons are case-insensitive. A bare id shared by several providers is
+ * reported as ambiguous with the candidates, so callers can list them.
+ */
+export function matchModelReference<M extends ModelRefLike>(
+  reference: string,
+  models: readonly M[]
+): ModelMatch<M> {
+  const ref = reference.trim().toLowerCase()
+  if (!ref) return { kind: 'none' }
+
+  const canonical = decide(models.filter((m) => `${m.provider}/${m.id}`.toLowerCase() === ref))
+  if (canonical) return canonical
+
+  const slash = ref.indexOf('/')
+  if (slash > 0 && slash < ref.length - 1) {
+    // Trimmed separately so "provider / id" with stray spaces still resolves.
+    const provider = ref.slice(0, slash).trim()
+    const id = ref.slice(slash + 1).trim()
+    const split = decide(
+      models.filter((m) => m.provider.toLowerCase() === provider && m.id.toLowerCase() === id)
+    )
+    if (split) return split
+  }
+
+  return decide(models.filter((m) => m.id.toLowerCase() === ref)) ?? { kind: 'none' }
+}

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -93,12 +93,17 @@ async function completeWithModel(
 export function resolveModel(ctx: ExtensionContext, cfg: Config): ResolvedModel | undefined {
   if (cfg.model && cfg.model !== 'default') {
     // /lang model saves canonical provider/id, but a hand-edited config may
-    // hold a bare id; match both the way pi's own resolver does. Restricting
-    // to configured-auth models keeps a bare id unambiguous when other
-    // providers' catalogs also list it, and an unauthenticated override
-    // could not complete anyway.
-    const match = matchModelReference(cfg.model, ctx.modelRegistry.getAvailable())
-    if (match.kind === 'found') return match.model
+    // hold a bare id; match both the way pi's own resolver does. Matching
+    // configured-auth models first keeps a bare id unambiguous when other
+    // providers' catalogs also list it.
+    const available = matchModelReference(cfg.model, ctx.modelRegistry.getAvailable())
+    if (available.kind === 'found') return available.model
+    // An override that exists in the catalog but lost its auth (/logout, env
+    // var removed) must fail the side-call visibly in runLlm — not silently
+    // re-route translations, and the conversation data, to the session
+    // model's provider.
+    const catalog = matchModelReference(cfg.model, ctx.modelRegistry.getAll())
+    if (catalog.kind === 'found') return catalog.model
   }
   return ctx.model
 }

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -93,8 +93,11 @@ async function completeWithModel(
 export function resolveModel(ctx: ExtensionContext, cfg: Config): ResolvedModel | undefined {
   if (cfg.model && cfg.model !== 'default') {
     // /lang model saves canonical provider/id, but a hand-edited config may
-    // hold a bare id; match both the way pi's own resolver does.
-    const match = matchModelReference(cfg.model, ctx.modelRegistry.getAll())
+    // hold a bare id; match both the way pi's own resolver does. Restricting
+    // to configured-auth models keeps a bare id unambiguous when other
+    // providers' catalogs also list it, and an unauthenticated override
+    // could not complete anyway.
+    const match = matchModelReference(cfg.model, ctx.modelRegistry.getAvailable())
     if (match.kind === 'found') return match.model
   }
   return ctx.model

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -15,7 +15,7 @@ import type {
 } from '@earendil-works/pi-ai/compat'
 import { convertToLlm } from '@earendil-works/pi-coding-agent'
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
-import { resolveModelReference } from './core.ts'
+import { resolveStoredModelReference } from './core.ts'
 import type { Config } from './core.ts'
 
 export type ResolvedModel = NonNullable<ExtensionContext['model']>
@@ -92,12 +92,12 @@ async function completeWithModel(
 /** The model to use for checks and translations: the configured override, else the session model. */
 export function resolveModel(ctx: ExtensionContext, cfg: Config): ResolvedModel | undefined {
   if (cfg.model && cfg.model !== 'default') {
-    // /lang model saves canonical provider/id, but a hand-edited config may
-    // hold a bare id; resolve both with pi CLI's semantics. `needsAuth` is
-    // returned too: an override whose provider lost its auth (/logout, env
-    // var removed) must fail visibly at runLlm's auth check, not silently
-    // re-route side-calls to the session model's provider.
-    const resolved = resolveModelReference(
+    // A saved canonical provider/id is restored exactly; only hand-edited
+    // bare ids go through CLI-style disambiguation. `needsAuth` is returned
+    // too: an override whose provider lost its auth (/logout, env var
+    // removed) must fail visibly at runLlm's auth check, not silently
+    // re-route side-calls to another provider.
+    const resolved = resolveStoredModelReference(
       cfg.model,
       ctx.modelRegistry.getAvailable(),
       ctx.modelRegistry.getAll()

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -15,6 +15,7 @@ import type {
 } from '@earendil-works/pi-ai/compat'
 import { convertToLlm } from '@earendil-works/pi-coding-agent'
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
+import { matchModelReference } from './core.ts'
 import type { Config } from './core.ts'
 
 export type ResolvedModel = NonNullable<ExtensionContext['model']>
@@ -91,11 +92,10 @@ async function completeWithModel(
 /** The model to use for checks and translations: the configured override, else the session model. */
 export function resolveModel(ctx: ExtensionContext, cfg: Config): ResolvedModel | undefined {
   if (cfg.model && cfg.model !== 'default') {
-    const slash = cfg.model.indexOf('/')
-    if (slash > 0) {
-      const found = ctx.modelRegistry.find(cfg.model.slice(0, slash), cfg.model.slice(slash + 1))
-      if (found) return found
-    }
+    // /lang model saves canonical provider/id, but a hand-edited config may
+    // hold a bare id; match both the way pi's own resolver does.
+    const match = matchModelReference(cfg.model, ctx.modelRegistry.getAll())
+    if (match.kind === 'found') return match.model
   }
   return ctx.model
 }

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -15,7 +15,7 @@ import type {
 } from '@earendil-works/pi-ai/compat'
 import { convertToLlm } from '@earendil-works/pi-coding-agent'
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
-import { matchModelReference } from './core.ts'
+import { resolveModelReference } from './core.ts'
 import type { Config } from './core.ts'
 
 export type ResolvedModel = NonNullable<ExtensionContext['model']>
@@ -93,17 +93,16 @@ async function completeWithModel(
 export function resolveModel(ctx: ExtensionContext, cfg: Config): ResolvedModel | undefined {
   if (cfg.model && cfg.model !== 'default') {
     // /lang model saves canonical provider/id, but a hand-edited config may
-    // hold a bare id; match both the way pi's own resolver does. Matching
-    // configured-auth models first keeps a bare id unambiguous when other
-    // providers' catalogs also list it.
-    const available = matchModelReference(cfg.model, ctx.modelRegistry.getAvailable())
-    if (available.kind === 'found') return available.model
-    // An override that exists in the catalog but lost its auth (/logout, env
-    // var removed) must fail the side-call visibly in runLlm — not silently
-    // re-route translations, and the conversation data, to the session
-    // model's provider.
-    const catalog = matchModelReference(cfg.model, ctx.modelRegistry.getAll())
-    if (catalog.kind === 'found') return catalog.model
+    // hold a bare id; resolve both with pi CLI's semantics. `needsAuth` is
+    // returned too: an override whose provider lost its auth (/logout, env
+    // var removed) must fail visibly at runLlm's auth check, not silently
+    // re-route side-calls to the session model's provider.
+    const resolved = resolveModelReference(
+      cfg.model,
+      ctx.modelRegistry.getAvailable(),
+      ctx.modelRegistry.getAll()
+    )
+    if (resolved.kind === 'found' || resolved.kind === 'needsAuth') return resolved.model
   }
   return ctx.model
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,7 +16,7 @@ import {
   Text
 } from '@earendil-works/pi-tui'
 import { loadConfig, saveConfig } from './config.ts'
-import { resolveModelReference } from './core.ts'
+import { resolveModelReference, resolveStoredModelReference } from './core.ts'
 import type { Config } from './core.ts'
 
 export const STATUS_KEY = 'language-learn'
@@ -36,10 +36,17 @@ export function warnOnCacheMismatch(ctx: ExtensionContext, cfg: Config): void {
   const sessionModel = `${ctx.model.provider}/${ctx.model.id}`
   // A hand-edited config may hold a bare id or a differently-cased ref that
   // still resolves to the session model; compare resolved identities, not
-  // the raw string.
-  const all = ctx.modelRegistry.getAll()
-  const match = resolveModelReference(cfg.model, all, all)
-  const override = match.kind === 'found' ? `${match.model.provider}/${match.model.id}` : cfg.model
+  // the raw string — using the exact same resolution runLlm's resolveModel
+  // uses, so the warning never contradicts what actually happens.
+  const match = resolveStoredModelReference(
+    cfg.model,
+    ctx.modelRegistry.getAvailable(),
+    ctx.modelRegistry.getAll()
+  )
+  const override =
+    match.kind === 'found' || match.kind === 'needsAuth'
+      ? `${match.model.provider}/${match.model.id}`
+      : cfg.model
   if (override === sessionModel) return
   ctx.ui.notify(
     `/lang model is ${override} but the session model is ${sessionModel} — context-mode translations can't reuse the session's prompt cache, so the whole history is re-billed at full input price on every translation, and the entire conversation (not just the translated text) is sent to ${override}'s provider. Run "/lang model default" to follow the session model.`,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,7 +16,7 @@ import {
   Text
 } from '@earendil-works/pi-tui'
 import { loadConfig, saveConfig } from './config.ts'
-import { matchModelReference } from './core.ts'
+import { resolveModelReference } from './core.ts'
 import type { Config } from './core.ts'
 
 export const STATUS_KEY = 'language-learn'
@@ -37,7 +37,8 @@ export function warnOnCacheMismatch(ctx: ExtensionContext, cfg: Config): void {
   // A hand-edited config may hold a bare id or a differently-cased ref that
   // still resolves to the session model; compare resolved identities, not
   // the raw string.
-  const match = matchModelReference(cfg.model, ctx.modelRegistry.getAll())
+  const all = ctx.modelRegistry.getAll()
+  const match = resolveModelReference(cfg.model, all, all)
   const override = match.kind === 'found' ? `${match.model.provider}/${match.model.id}` : cfg.model
   if (override === sessionModel) return
   ctx.ui.notify(
@@ -348,38 +349,43 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
           if (value === 'default') {
             cfg.model = undefined
           } else {
-            // Resolve against configured-auth models, like pi's own /model:
-            // a bare id shadowed by unconfigured providers' catalogs stays
-            // unambiguous. The full catalog is only consulted for the error
-            // message, to tell "needs /login" apart from "does not exist".
-            const match = matchModelReference(value, ctx.modelRegistry.getAvailable())
-            if (match.kind === 'ambiguous') {
-              const refs = match.candidates.map((m) => `${m.provider}/${m.id}`).join(', ')
+            // pi CLI's -m semantics: provider-prefix interpretation first,
+            // auth-aware tiebreak, then the whole reference as a raw model id
+            // (OpenRouter-style). The full catalog shapes the errors, to tell
+            // "needs /login" apart from "does not exist".
+            const resolved = resolveModelReference(
+              value,
+              ctx.modelRegistry.getAvailable(),
+              ctx.modelRegistry.getAll()
+            )
+            if (resolved.kind === 'ambiguous') {
+              const refs = resolved.candidates.map((m) => `${m.provider}/${m.id}`).join(', ')
               ctx.ui.notify(`Ambiguous model id: ${value} — use one of: ${refs}`, 'warning')
               return
             }
-            if (match.kind === 'none') {
-              const inCatalog = matchModelReference(value, ctx.modelRegistry.getAll())
-              if (inCatalog.kind === 'found') {
-                ctx.ui.notify(
-                  `No auth configured for ${inCatalog.model.provider}/${inCatalog.model.id} — run /login ${inCatalog.model.provider} first`,
-                  'warning'
-                )
-              } else if (inCatalog.kind === 'ambiguous') {
-                const refs = inCatalog.candidates.map((m) => `${m.provider}/${m.id}`).join(', ')
-                ctx.ui.notify(
-                  `No auth configured for any provider of ${value} (${refs}) — run /login first`,
-                  'warning'
-                )
-              } else {
-                ctx.ui.notify(
-                  `Model not found: ${value} (expected <provider>/<id> or a unique model id)`,
-                  'warning'
-                )
-              }
+            if (resolved.kind === 'needsAuth') {
+              ctx.ui.notify(
+                `No auth configured for ${resolved.model.provider}/${resolved.model.id} — run /login ${resolved.model.provider} first`,
+                'warning'
+              )
               return
             }
-            const found = match.model
+            if (resolved.kind === 'noAuthAnywhere') {
+              const refs = resolved.candidates.map((m) => `${m.provider}/${m.id}`).join(', ')
+              ctx.ui.notify(
+                `No auth configured for any provider of ${value} (${refs}) — run /login first`,
+                'warning'
+              )
+              return
+            }
+            if (resolved.kind === 'none') {
+              ctx.ui.notify(
+                `Model not found: ${value} (expected <provider>/<id> or a unique model id)`,
+                'warning'
+              )
+              return
+            }
+            const found = resolved.model
             cfg.model = `${found.provider}/${found.id}`
             warnOnCacheMismatch(ctx, cfg)
           }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,9 +34,14 @@ export function updateStatus(ctx: ExtensionContext, cfg: Config): void {
 export function warnOnCacheMismatch(ctx: ExtensionContext, cfg: Config): void {
   if (!cfg.context || !cfg.model || cfg.model === 'default' || !ctx.model) return
   const sessionModel = `${ctx.model.provider}/${ctx.model.id}`
-  if (cfg.model === sessionModel) return
+  // A hand-edited config may hold a bare id or a differently-cased ref that
+  // still resolves to the session model; compare resolved identities, not
+  // the raw string.
+  const match = matchModelReference(cfg.model, ctx.modelRegistry.getAll())
+  const override = match.kind === 'found' ? `${match.model.provider}/${match.model.id}` : cfg.model
+  if (override === sessionModel) return
   ctx.ui.notify(
-    `/lang model is ${cfg.model} but the session model is ${sessionModel} — context-mode translations can't reuse the session's prompt cache, so the whole history is re-billed at full input price on every translation, and the entire conversation (not just the translated text) is sent to ${cfg.model}'s provider. Run "/lang model default" to follow the session model.`,
+    `/lang model is ${override} but the session model is ${sessionModel} — context-mode translations can't reuse the session's prompt cache, so the whole history is re-billed at full input price on every translation, and the entire conversation (not just the translated text) is sent to ${override}'s provider. Run "/lang model default" to follow the session model.`,
     'warning'
   )
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ import {
   Text
 } from '@earendil-works/pi-tui'
 import { loadConfig, saveConfig } from './config.ts'
+import { matchModelReference } from './core.ts'
 import type { Config } from './core.ts'
 
 export const STATUS_KEY = 'language-learn'
@@ -41,7 +42,7 @@ export function warnOnCacheMismatch(ctx: ExtensionContext, cfg: Config): void {
 }
 
 const LANG_USAGE =
-  'Usage: /lang  (settings menu)  |  /lang on|off  |  /lang auto|context on|off  |  /lang native|learning <code>  |  /lang model <provider/id|default>'
+  'Usage: /lang  (settings menu)  |  /lang on|off  |  /lang auto|context on|off  |  /lang native|learning <code>  |  /lang model <provider/id|id|default>'
 
 const LANGUAGE_PRESETS: ReadonlyArray<{ code: string; name: string }> = [
   { code: 'en', name: 'English' },
@@ -333,21 +334,29 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
           break
         case 'model':
           if (!value) {
-            ctx.ui.notify('Usage: /lang model <provider/id> or /lang model default', 'warning')
+            ctx.ui.notify(
+              'Usage: /lang model <provider/id>, a unique model id, or default',
+              'warning'
+            )
             return
           }
           if (value === 'default') {
             cfg.model = undefined
           } else {
-            const slash = value.indexOf('/')
-            const found =
-              slash > 0
-                ? ctx.modelRegistry.find(value.slice(0, slash), value.slice(slash + 1))
-                : undefined
-            if (!found) {
-              ctx.ui.notify(`Model not found: ${value} (expected <provider>/<id>)`, 'warning')
+            const match = matchModelReference(value, ctx.modelRegistry.getAll())
+            if (match.kind === 'ambiguous') {
+              const refs = match.candidates.map((m) => `${m.provider}/${m.id}`).join(', ')
+              ctx.ui.notify(`Ambiguous model id: ${value} — use one of: ${refs}`, 'warning')
               return
             }
+            if (match.kind === 'none') {
+              ctx.ui.notify(
+                `Model not found: ${value} (expected <provider>/<id> or a unique model id)`,
+                'warning'
+              )
+              return
+            }
+            const found = match.model
             const hasAuth = ctx.modelRegistry
               .getAvailable()
               .some((m) => m.provider === found.provider && m.id === found.id)
@@ -358,7 +367,7 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
               )
               return
             }
-            cfg.model = value
+            cfg.model = `${found.provider}/${found.id}`
             warnOnCacheMismatch(ctx, cfg)
           }
           saveConfig(cfg)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,8 +47,49 @@ export function warnOnCacheMismatch(ctx: ExtensionContext, cfg: Config): void {
   )
 }
 
+/** Options for the model pickers: default (session model) + configured-auth models. */
+function modelOptions(ctx: ExtensionContext): SelectItem[] {
+  return [
+    { value: 'default', label: 'default', description: 'follow the session model' },
+    ...ctx.modelRegistry.getAvailable().map((m) => ({
+      value: `${m.provider}/${m.id}`,
+      label: `${m.provider}/${m.id}`,
+      description: m.name
+    }))
+  ]
+}
+
+/** Standalone model picker for bare `/lang model` — same list as the menu's submenu. */
+async function openModelPicker(ctx: ExtensionContext, cfg: Config): Promise<void> {
+  const selected = await ctx.ui.custom<string | undefined>((tui, theme, _kb, done) => {
+    const options = modelOptions(ctx)
+    const list = new SelectList(options, Math.min(options.length, 10), getSelectListTheme())
+    const preselect = options.findIndex((o) => o.value === (cfg.model ?? 'default'))
+    if (preselect >= 0) list.setSelectedIndex(preselect)
+    list.onSelect = (item) => done(item.value)
+    list.onCancel = () => done(undefined)
+    return {
+      render: (width: number) => [
+        theme.fg('accent', theme.bold(' Model')),
+        '',
+        ...list.render(width)
+      ],
+      invalidate: () => {},
+      handleInput: (data: string) => {
+        list.handleInput(data)
+        tui.requestRender()
+      }
+    }
+  })
+  if (selected === undefined) return
+  cfg.model = selected === 'default' ? undefined : selected
+  saveConfig(cfg)
+  if (cfg.model) warnOnCacheMismatch(ctx, cfg)
+  updateStatus(ctx, cfg)
+}
+
 const LANG_USAGE =
-  'Usage: /lang  (settings menu)  |  /lang on|off  |  /lang auto|context on|off  |  /lang native|learning <code>  |  /lang model <provider/id|id|default>'
+  'Usage: /lang  (settings menu)  |  /lang on|off  |  /lang auto|context on|off  |  /lang native|learning <code>  |  /lang model [provider/id|id|default]'
 
 const LANGUAGE_PRESETS: ReadonlyArray<{ code: string; name: string }> = [
   { code: 'en', name: 'English' },
@@ -171,14 +212,7 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
 
       /** Submenu: models with configured auth (same source as the built-in /model selector). */
       const modelSubmenu = (currentValue: string, submenuDone: (value?: string) => void) => {
-        const options: SelectItem[] = [
-          { value: 'default', label: 'default', description: 'follow the session model' },
-          ...ctx.modelRegistry.getAvailable().map((m) => ({
-            value: `${m.provider}/${m.id}`,
-            label: `${m.provider}/${m.id}`,
-            description: m.name
-          }))
-        ]
+        const options = modelOptions(ctx)
         const list = new SelectList(options, Math.min(options.length, 10), getSelectListTheme())
         const preselect = options.findIndex((o) => o.value === currentValue)
         if (preselect >= 0) list.setSelectedIndex(preselect)
@@ -340,10 +374,15 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
           break
         case 'model':
           if (!value) {
-            ctx.ui.notify(
-              'Usage: /lang model <provider/id>, a unique model id, or default',
-              'warning'
-            )
+            if (ctx.hasUI && ctx.mode === 'tui') {
+              await openModelPicker(ctx, cfg)
+              show()
+            } else {
+              ctx.ui.notify(
+                'Usage: /lang model <provider/id>, a unique model id, or default',
+                'warning'
+              )
+            }
             return
           }
           if (value === 'default') {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -343,30 +343,38 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
           if (value === 'default') {
             cfg.model = undefined
           } else {
-            const match = matchModelReference(value, ctx.modelRegistry.getAll())
+            // Resolve against configured-auth models, like pi's own /model:
+            // a bare id shadowed by unconfigured providers' catalogs stays
+            // unambiguous. The full catalog is only consulted for the error
+            // message, to tell "needs /login" apart from "does not exist".
+            const match = matchModelReference(value, ctx.modelRegistry.getAvailable())
             if (match.kind === 'ambiguous') {
               const refs = match.candidates.map((m) => `${m.provider}/${m.id}`).join(', ')
               ctx.ui.notify(`Ambiguous model id: ${value} — use one of: ${refs}`, 'warning')
               return
             }
             if (match.kind === 'none') {
-              ctx.ui.notify(
-                `Model not found: ${value} (expected <provider>/<id> or a unique model id)`,
-                'warning'
-              )
+              const inCatalog = matchModelReference(value, ctx.modelRegistry.getAll())
+              if (inCatalog.kind === 'found') {
+                ctx.ui.notify(
+                  `No auth configured for ${inCatalog.model.provider}/${inCatalog.model.id} — run /login ${inCatalog.model.provider} first`,
+                  'warning'
+                )
+              } else if (inCatalog.kind === 'ambiguous') {
+                const refs = inCatalog.candidates.map((m) => `${m.provider}/${m.id}`).join(', ')
+                ctx.ui.notify(
+                  `No auth configured for any provider of ${value} (${refs}) — run /login first`,
+                  'warning'
+                )
+              } else {
+                ctx.ui.notify(
+                  `Model not found: ${value} (expected <provider>/<id> or a unique model id)`,
+                  'warning'
+                )
+              }
               return
             }
             const found = match.model
-            const hasAuth = ctx.modelRegistry
-              .getAvailable()
-              .some((m) => m.provider === found.provider && m.id === found.id)
-            if (!hasAuth) {
-              ctx.ui.notify(
-                `No auth configured for ${value} — run /login ${found.provider} first`,
-                'warning'
-              )
-              return
-            }
             cfg.model = `${found.provider}/${found.id}`
             warnOnCacheMismatch(ctx, cfg)
           }

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -7,7 +7,7 @@ import {
   buildSegmentPrompt,
   buildWholeTranslatePrompt,
   CONTEXT_PREFACE,
-  matchModelReference,
+  resolveModelReference,
   getProviderStreamSimple
 } from '../language-learn.ts'
 import { resolveModel } from '../src/llm.ts'
@@ -226,52 +226,70 @@ describe('getProviderStreamSimple (custom providers, e.g. cursor-sdk)', () => {
   })
 })
 
-describe('matchModelReference', () => {
-  const models = [
-    { provider: 'openai', id: 'gpt-4o-mini' },
-    { provider: 'azure', id: 'gpt-4o-mini' },
-    { provider: 'anthropic', id: 'claude-sonnet-5' },
-    { provider: 'openrouter', id: 'openai/gpt-4o-mini' }
-  ]
+describe('resolveModelReference (pi CLI -m semantics)', () => {
+  const zai = { provider: 'zai', id: 'glm-5' }
+  const gateway = { provider: 'gateway', id: 'zai/glm-5' }
+  const openai = { provider: 'openai', id: 'gpt-4o-mini' }
+  const azure = { provider: 'azure', id: 'gpt-4o-mini' }
+  const catalog = [zai, gateway, openai, azure]
 
-  it('canonical provider/id wins over a same-named bare id elsewhere', () => {
-    expect(matchModelReference('openai/gpt-4o-mini', models)).toEqual({
+  it('prefers the provider interpretation over a raw-id lookalike', () => {
+    expect(resolveModelReference('zai/glm-5', catalog, catalog)).toEqual({
       kind: 'found',
-      model: { provider: 'openai', id: 'gpt-4o-mini' }
+      model: zai
     })
   })
-  it('resolves a model id that itself contains a slash', () => {
-    expect(matchModelReference('openrouter/openai/gpt-4o-mini', models)).toEqual({
+  it('canonical ref reaches a model whose id contains a slash', () => {
+    expect(resolveModelReference('gateway/zai/glm-5', catalog, catalog)).toEqual({
       kind: 'found',
-      model: { provider: 'openrouter', id: 'openai/gpt-4o-mini' }
+      model: gateway
     })
   })
-  it('resolves a unique bare id', () => {
-    expect(matchModelReference('claude-sonnet-5', models)).toEqual({
+  it('auth-aware tiebreak: unauthed provider ref falls to the unique authed raw id', () => {
+    expect(resolveModelReference('zai/glm-5', [gateway], catalog)).toEqual({
       kind: 'found',
-      model: { provider: 'anthropic', id: 'claude-sonnet-5' }
+      model: gateway
+    })
+  })
+  it('needsAuth when the provider ref has no authed raw-id lookalike', () => {
+    expect(resolveModelReference('openai/gpt-4o-mini', [azure], catalog)).toEqual({
+      kind: 'needsAuth',
+      model: openai
+    })
+  })
+  it('known provider without that model still matches the whole ref as a raw id', () => {
+    const zaiOther = { provider: 'zai', id: 'glm-4' }
+    expect(resolveModelReference('zai/glm-5', [gateway, zaiOther], [gateway, zaiOther])).toEqual({
+      kind: 'found',
+      model: gateway
+    })
+  })
+  it('resolves a unique bare id among configured-auth models', () => {
+    expect(resolveModelReference('glm-5', [zai, openai], catalog)).toEqual({
+      kind: 'found',
+      model: zai
     })
   })
   it('reports an ambiguous bare id with its candidates', () => {
-    expect(matchModelReference('gpt-4o-mini', models)).toEqual({
+    expect(resolveModelReference('gpt-4o-mini', catalog, catalog)).toEqual({
       kind: 'ambiguous',
-      candidates: [
-        { provider: 'openai', id: 'gpt-4o-mini' },
-        { provider: 'azure', id: 'gpt-4o-mini' }
-      ]
+      candidates: [openai, azure]
+    })
+  })
+  it('bare id known only to unconfigured catalogs reports noAuthAnywhere', () => {
+    expect(resolveModelReference('gpt-4o-mini', [], catalog)).toEqual({
+      kind: 'noAuthAnywhere',
+      candidates: [openai, azure]
     })
   })
   it('matches case-insensitively', () => {
-    expect(matchModelReference('Anthropic/Claude-Sonnet-5', models).kind).toBe('found')
-  })
-  it('tolerates spaces around the slash', () => {
-    expect(matchModelReference('anthropic / claude-sonnet-5', models).kind).toBe('found')
+    expect(resolveModelReference('ZAI/GLM-5', catalog, catalog).kind).toBe('found')
   })
   it('unknown reference', () => {
-    expect(matchModelReference('gpt-nonexistent', models)).toEqual({ kind: 'none' })
+    expect(resolveModelReference('gpt-nonexistent', catalog, catalog)).toEqual({ kind: 'none' })
   })
   it('empty reference', () => {
-    expect(matchModelReference('  ', models)).toEqual({ kind: 'none' })
+    expect(resolveModelReference('  ', catalog, catalog)).toEqual({ kind: 'none' })
   })
 })
 
@@ -284,7 +302,7 @@ const lang = (model?: string, context = false) => ({
   context
 })
 
-describe('resolveModel (available-first, catalog fallback)', () => {
+describe('resolveModel (pi CLI semantics over available/catalog)', () => {
   const openai = { provider: 'openai', id: 'gpt-4o-mini' }
   const azure = { provider: 'azure', id: 'gpt-4o-mini' }
   const cloudflare = { provider: 'cloudflare', id: 'gpt-4o-mini' }
@@ -342,5 +360,39 @@ describe('warnOnCacheMismatch', () => {
     const notes: string[] = []
     warnOnCacheMismatch(ctx(notes), lang('glm-5', false) as never)
     expect(notes).toEqual([])
+  })
+})
+
+describe('slash-containing refs follow pi CLI semantics (OpenRouter-style ids)', () => {
+  const openai = { provider: 'openai', id: 'gpt-4o-mini' }
+  const openrouter = { provider: 'openrouter', id: 'openai/gpt-4o-mini' }
+  const session = { provider: 'anthropic', id: 'claude-sonnet-5' }
+  const catalog = [openai, openrouter, session]
+  const ctx = (available: unknown[]) =>
+    ({
+      modelRegistry: { getAvailable: () => available, getAll: () => catalog },
+      model: session
+    }) as never
+
+  it('unauthed provider ref with a unique authed raw-id lookalike takes the authed model (pi tiebreak)', () => {
+    expect(resolveModel(ctx([openrouter, session]), lang('openai/gpt-4o-mini') as never)).toBe(
+      openrouter
+    )
+  })
+  it('the openrouter model stays reachable through its canonical ref', () => {
+    expect(
+      resolveModel(ctx([openrouter, session]), lang('openrouter/openai/gpt-4o-mini') as never)
+    ).toBe(openrouter)
+  })
+  it('a slash-containing reference matching no catalog provider still resolves as a bare id', () => {
+    const orphan = { provider: 'openrouter', id: 'mistral/devstral' }
+    const registry = {
+      modelRegistry: { getAvailable: () => [orphan, session], getAll: () => [orphan, session] },
+      model: session
+    } as never
+    expect(resolveModel(registry, lang('mistral/devstral') as never)).toBe(orphan)
+  })
+  it('a bare id that lost auth everywhere still resolves from the catalog (fails visibly later)', () => {
+    expect(resolveModel(ctx([session]), lang('gpt-4o-mini') as never)).toBe(openai)
   })
 })

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -386,11 +386,11 @@ describe('slash-containing refs follow pi CLI semantics (OpenRouter-style ids)',
   })
   it('a slash-containing reference matching no catalog provider still resolves as a bare id', () => {
     const orphan = { provider: 'openrouter', id: 'mistral/devstral' }
-    const registry = {
+    const orphanCtx = {
       modelRegistry: { getAvailable: () => [orphan, session], getAll: () => [orphan, session] },
       model: session
     } as never
-    expect(resolveModel(registry, lang('mistral/devstral') as never)).toBe(orphan)
+    expect(resolveModel(orphanCtx, lang('mistral/devstral') as never)).toBe(orphan)
   })
   it('a bare id that lost auth everywhere still resolves from the catalog (fails visibly later)', () => {
     expect(resolveModel(ctx([session]), lang('gpt-4o-mini') as never)).toBe(openai)

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -10,7 +10,9 @@ import {
   matchModelReference,
   getProviderStreamSimple
 } from '../language-learn.ts'
+import { resolveModel } from '../src/llm.ts'
 import type { StreamSimpleRegistry } from '../src/llm.ts'
+import { warnOnCacheMismatch } from '../src/settings.ts'
 
 describe('shouldSkipCheck', () => {
   describe('inputs that must be skipped', () => {
@@ -270,5 +272,75 @@ describe('matchModelReference', () => {
   })
   it('empty reference', () => {
     expect(matchModelReference('  ', models)).toEqual({ kind: 'none' })
+  })
+})
+
+const lang = (model?: string, context = false) => ({
+  learning: 'en',
+  native: 'zh-CN',
+  model,
+  enabled: true,
+  auto: false,
+  context
+})
+
+describe('resolveModel (available-first, catalog fallback)', () => {
+  const openai = { provider: 'openai', id: 'gpt-4o-mini' }
+  const azure = { provider: 'azure', id: 'gpt-4o-mini' }
+  const cloudflare = { provider: 'cloudflare', id: 'gpt-4o-mini' }
+  const session = { provider: 'anthropic', id: 'claude-sonnet-5' }
+  const catalog = [openai, azure, cloudflare, session]
+  const ctx = (available: unknown[]) =>
+    ({
+      modelRegistry: { getAvailable: () => available, getAll: () => catalog },
+      model: session
+    }) as never
+
+  it('resolves a bare id against configured-auth models even when other catalogs list it', () => {
+    expect(resolveModel(ctx([openai, session]), lang('gpt-4o-mini') as never)).toBe(openai)
+  })
+  it('an override that lost auth still resolves from the catalog (fails visibly later)', () => {
+    expect(resolveModel(ctx([session]), lang('openai/gpt-4o-mini') as never)).toBe(openai)
+  })
+  it('a bare id ambiguous among available models falls back to the session model', () => {
+    expect(resolveModel(ctx([openai, azure, session]), lang('gpt-4o-mini') as never)).toBe(session)
+  })
+  it('an unknown override falls back to the session model', () => {
+    expect(resolveModel(ctx([session]), lang('gpt-nonexistent') as never)).toBe(session)
+  })
+  it('no override uses the session model', () => {
+    expect(resolveModel(ctx([session]), lang(undefined) as never)).toBe(session)
+  })
+})
+
+describe('warnOnCacheMismatch', () => {
+  const session = { provider: 'openai', id: 'gpt-4o-mini' }
+  const other = { provider: 'zai', id: 'glm-5' }
+  const ctx = (notes: string[]) =>
+    ({
+      model: session,
+      modelRegistry: { getAll: () => [session, other] },
+      ui: {
+        notify: (msg: string) => {
+          notes.push(msg)
+        }
+      }
+    }) as never
+
+  it('does not warn when a hand-edited ref resolves to the session model', () => {
+    const notes: string[] = []
+    warnOnCacheMismatch(ctx(notes), lang('GPT-4O-MINI', true) as never)
+    expect(notes).toEqual([])
+  })
+  it('warns when the override resolves to a different model', () => {
+    const notes: string[] = []
+    warnOnCacheMismatch(ctx(notes), lang('glm-5', true) as never)
+    expect(notes).toHaveLength(1)
+    expect(notes[0]).toContain('zai/glm-5')
+  })
+  it('stays quiet while context mode is off', () => {
+    const notes: string[] = []
+    warnOnCacheMismatch(ctx(notes), lang('glm-5', false) as never)
+    expect(notes).toEqual([])
   })
 })

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -8,6 +8,7 @@ import {
   buildWholeTranslatePrompt,
   CONTEXT_PREFACE,
   resolveModelReference,
+  resolveStoredModelReference,
   getProviderStreamSimple
 } from '../language-learn.ts'
 import { resolveModel } from '../src/llm.ts'
@@ -334,10 +335,11 @@ describe('resolveModel (pi CLI semantics over available/catalog)', () => {
 describe('warnOnCacheMismatch', () => {
   const session = { provider: 'openai', id: 'gpt-4o-mini' }
   const other = { provider: 'zai', id: 'glm-5' }
-  const ctx = (notes: string[]) =>
+  const azureDup = { provider: 'azure', id: 'gpt-4o-mini' }
+  const ctx = (notes: string[], available = [session, other], all = [session, other]) =>
     ({
       model: session,
-      modelRegistry: { getAll: () => [session, other] },
+      modelRegistry: { getAvailable: () => available, getAll: () => all },
       ui: {
         notify: (msg: string) => {
           notes.push(msg)
@@ -361,6 +363,39 @@ describe('warnOnCacheMismatch', () => {
     warnOnCacheMismatch(ctx(notes), lang('glm-5', false) as never)
     expect(notes).toEqual([])
   })
+  it('uses the same available/catalog resolution as runLlm: an unauthed catalog duplicate does not fake a mismatch', () => {
+    const notes: string[] = []
+    warnOnCacheMismatch(
+      ctx(notes, [session, other], [session, other, azureDup]),
+      lang('gpt-4o-mini', true) as never
+    )
+    expect(notes).toEqual([])
+  })
+})
+
+describe('resolveStoredModelReference (saved config refs)', () => {
+  const openai = { provider: 'openai', id: 'gpt-4o-mini' }
+  const openrouter = { provider: 'openrouter', id: 'openai/gpt-4o-mini' }
+  const catalog = [openai, openrouter]
+
+  it('restores a saved canonical ref exactly, as needsAuth when its provider lost auth', () => {
+    expect(resolveStoredModelReference('openai/gpt-4o-mini', [openrouter], catalog)).toEqual({
+      kind: 'needsAuth',
+      model: openai
+    })
+  })
+  it('returns found when the saved canonical ref still has auth', () => {
+    expect(resolveStoredModelReference('openai/gpt-4o-mini', [openai], catalog)).toEqual({
+      kind: 'found',
+      model: openai
+    })
+  })
+  it('falls back to interactive semantics for a hand-edited bare id', () => {
+    expect(resolveStoredModelReference('gpt-4o-mini', [openai], catalog)).toEqual({
+      kind: 'found',
+      model: openai
+    })
+  })
 })
 
 describe('slash-containing refs follow pi CLI semantics (OpenRouter-style ids)', () => {
@@ -374,9 +409,9 @@ describe('slash-containing refs follow pi CLI semantics (OpenRouter-style ids)',
       model: session
     }) as never
 
-  it('unauthed provider ref with a unique authed raw-id lookalike takes the authed model (pi tiebreak)', () => {
+  it('a saved canonical override is restored exactly even when an authed raw-id lookalike exists', () => {
     expect(resolveModel(ctx([openrouter, session]), lang('openai/gpt-4o-mini') as never)).toBe(
-      openrouter
+      openai
     )
   })
   it('the openrouter model stays reachable through its canonical ref', () => {

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -396,6 +396,19 @@ describe('resolveStoredModelReference (saved config refs)', () => {
       model: openai
     })
   })
+  it('a saved provider ref whose model left the catalog is not raw-matched onto a lookalike', () => {
+    const openaiOther = { provider: 'openai', id: 'gpt-4o' }
+    expect(
+      resolveStoredModelReference('openai/gpt-4o-mini', [openrouter], [openaiOther, openrouter])
+    ).toEqual({ kind: 'none' })
+  })
+  it('a raw id whose prefix names no provider still resolves interactively', () => {
+    const orphan = { provider: 'openrouter', id: 'mistral/devstral' }
+    expect(resolveStoredModelReference('mistral/devstral', [orphan], [orphan])).toEqual({
+      kind: 'found',
+      model: orphan
+    })
+  })
 })
 
 describe('slash-containing refs follow pi CLI semantics (OpenRouter-style ids)', () => {

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -7,6 +7,7 @@ import {
   buildSegmentPrompt,
   buildWholeTranslatePrompt,
   CONTEXT_PREFACE,
+  matchModelReference,
   getProviderStreamSimple
 } from '../language-learn.ts'
 import type { StreamSimpleRegistry } from '../src/llm.ts'
@@ -220,5 +221,54 @@ describe('getProviderStreamSimple (custom providers, e.g. cursor-sdk)', () => {
     expect(
       getProviderStreamSimple(registry(undefined), { provider: 'cursor', api: 'cursor-sdk' })
     ).toBeUndefined()
+  })
+})
+
+describe('matchModelReference', () => {
+  const models = [
+    { provider: 'openai', id: 'gpt-4o-mini' },
+    { provider: 'azure', id: 'gpt-4o-mini' },
+    { provider: 'anthropic', id: 'claude-sonnet-5' },
+    { provider: 'openrouter', id: 'openai/gpt-4o-mini' }
+  ]
+
+  it('canonical provider/id wins over a same-named bare id elsewhere', () => {
+    expect(matchModelReference('openai/gpt-4o-mini', models)).toEqual({
+      kind: 'found',
+      model: { provider: 'openai', id: 'gpt-4o-mini' }
+    })
+  })
+  it('resolves a model id that itself contains a slash', () => {
+    expect(matchModelReference('openrouter/openai/gpt-4o-mini', models)).toEqual({
+      kind: 'found',
+      model: { provider: 'openrouter', id: 'openai/gpt-4o-mini' }
+    })
+  })
+  it('resolves a unique bare id', () => {
+    expect(matchModelReference('claude-sonnet-5', models)).toEqual({
+      kind: 'found',
+      model: { provider: 'anthropic', id: 'claude-sonnet-5' }
+    })
+  })
+  it('reports an ambiguous bare id with its candidates', () => {
+    expect(matchModelReference('gpt-4o-mini', models)).toEqual({
+      kind: 'ambiguous',
+      candidates: [
+        { provider: 'openai', id: 'gpt-4o-mini' },
+        { provider: 'azure', id: 'gpt-4o-mini' }
+      ]
+    })
+  })
+  it('matches case-insensitively', () => {
+    expect(matchModelReference('Anthropic/Claude-Sonnet-5', models).kind).toBe('found')
+  })
+  it('tolerates spaces around the slash', () => {
+    expect(matchModelReference('anthropic / claude-sonnet-5', models).kind).toBe('found')
+  })
+  it('unknown reference', () => {
+    expect(matchModelReference('gpt-nonexistent', models)).toEqual({ kind: 'none' })
+  })
+  it('empty reference', () => {
+    expect(matchModelReference('  ', models)).toEqual({ kind: 'none' })
   })
 })


### PR DESCRIPTION
## Summary
- `/lang model gpt-4o-mini` failed with `Model not found: gpt-4o-mini (expected <provider>/<id>)` — the command hard-required a `provider/` prefix, stricter than pi's own convention (AGENTS.md: match pi ecosystem conventions before inventing UX). Closes #9.
- New pure `matchModelReference` in `src/core.ts` mirrors pi's resolver order (`core/model-resolver.ts`, `findExactModelReferenceMatch`): canonical `provider/id` match — which also keeps ids that themselves contain slashes working (`openrouter/openai/gpt-4o-mini`) — then a first-slash split tolerant of stray spaces, then bare id; case-insensitive throughout. pi's implementation ships in the package dist but is blocked by the `exports` map, hence the local pure version (which also fits the core.ts unit-test-surface rule).
- Improvement over pi's resolver: an ambiguous bare id lists the candidate `provider/id` refs in the warning instead of a bare failure.
- `/lang model` now saves the canonical `provider/id`; `resolveModel` runs the same matcher, so a bare id hand-edited into `~/.pi/agent/language-learn.json` resolves too.
- READMEs (both languages) and usage strings updated.

## Verification
- `npm run check` passes
- `npm test`: 44/44 (8 new `matchModelReference` cases: canonical, slash-in-id, unique bare id, ambiguous bare id with candidates, case-insensitivity, spaces around slash, unknown, empty)
- `npm run lint`: 0 errors (1 pre-existing warning in `src/translate.ts`, untouched); `npm run fmt:check` clean
- Resolution semantics cross-checked against pi `origin/main` `findExactModelReferenceMatch`