### PR TITLE
feat(grammar): make the writing check tri-state with a context mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,18 @@ That is enough to start.
 
 Type `/lang` in the TUI to open the interactive settings menu, or set things directly with the commands below.
 
-| Command                     | What it does                                                                              |
-| --------------------------- | ----------------------------------------------------------------------------------------- |
-| `/translate` or `alt+t`     | Translate the last assistant response (bilingual card)                                    |
-| `/lang`                     | Open the interactive settings menu — every option with an inline description              |
-| `/lang on` \| `off`         | Resume / pause the writing check & tutor                                                  |
-| `/lang tutor on` \| `off`   | Keep / drop just the writing tutor (off: native-language prompts show no panel)           |
-| `/lang auto on` \| `off`    | Auto-translate every final response                                                       |
-| `/lang native <code>`       | Set your native language — translation target and explanation language (`zh-CN`, `ja`, …) |
-| `/lang learning <code>`     | Set the language you are practicing (`en`, `fr`, …)                                       |
-| `/lang model [model]`       | Set the model this extension uses                                                         |
-| `/lang model default`       | Go back to the session model                                                              |
-| `/lang context on` \| `off` | Give translations the full session context (off by default; see below)                    |
+| Command                                | What it does                                                                                                           |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `/translate` or `alt+t`                | Translate the last assistant response (bilingual card)                                                                 |
+| `/lang`                                | Open the interactive settings menu — every option with an inline description                                           |
+| `/lang check off` \| `on` \| `context` | Writing check & tutor mode — `context` lets the review see the conversation (`/lang on`/`off` still work as shortcuts) |
+| `/lang tutor on` \| `off`              | Keep / drop just the writing tutor (off: native-language prompts show no panel)                                        |
+| `/lang auto on` \| `off`               | Auto-translate every final response                                                                                    |
+| `/lang native <code>`                  | Set your native language — translation target and explanation language (`zh-CN`, `ja`, …)                              |
+| `/lang learning <code>`                | Set the language you are practicing (`en`, `fr`, …)                                                                    |
+| `/lang model [model]`                  | Set the model this extension uses                                                                                      |
+| `/lang model default`                  | Go back to the session model                                                                                           |
+| `/lang context on` \| `off`            | Give translations the full session context (off by default; see below)                                                 |
 
 ## Configuration
 
@@ -97,7 +97,7 @@ Settings persist in `~/.pi/agent/language-learn.json`.
   "learning": "en",
   "native": "zh-CN",
   "model": "openai/gpt-4o-mini",
-  "enabled": true,
+  "check": "on",
   "auto": false,
   "context": false
 }
@@ -119,6 +119,8 @@ Settings persist in `~/.pi/agent/language-learn.json`.
 
 - It only pays off when translations use the **session model** — a `/lang model` override can't hit the session's cache, and the whole history would be re-billed at full input price on every translation. It also changes where your data goes: with an override, the entire conversation is sent to the override model's provider, not just the text being translated. The extension warns about this combination at startup and when you switch; `/lang model default` fixes it.
 - Before the first agent turn of a session there is no captured request yet, so translations quietly fall back to context-free.
+
+The writing check & tutor has its own context state (`/lang check context`), kept separate on purpose: the review fires on every message you send, so each reviewed message costs one cache read. Enable it only if the check keeps flagging project terms as errors — a contextual review recognizes names and coined words the session established, and the tutor can use them when teaching you how to express the message.
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,18 +73,18 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 在 TUI 中输入 `/lang` 打开交互式设置菜单，也可以用下面的命令直接设置。
 
-| 命令                        | 作用                                               |
-| --------------------------- | -------------------------------------------------- |
-| `/translate` 或 `alt+t`     | 翻译 agent 回复（双语卡片）                        |
-| `/lang`                     | 打开交互式设置菜单，每个选项都有一行说明           |
-| `/lang on` \| `off`         | 恢复/暂停写作检查与写作辅导                        |
-| `/lang tutor on` \| `off`   | 单独开关写作辅导（关闭后母语消息不再显示面板）     |
-| `/lang auto on` \| `off`    | 自动翻译每轮最终回复                               |
-| `/lang native <code>`       | 设置母语，即译文和讲解使用的语言（`zh-CN`、`ja`…） |
-| `/lang learning <code>`     | 设置正在学习的语言（`en`、`fr`…）                  |
-| `/lang model [model]`       | 指定本插件使用的模型                               |
-| `/lang model default`       | 换回会话模型                                       |
-| `/lang context on` \| `off` | 翻译时携带完整会话上下文（默认关闭，详见下文）     |
+| 命令                                   | 作用                                                                                  |
+| -------------------------------------- | ------------------------------------------------------------------------------------- |
+| `/translate` 或 `alt+t`                | 翻译 agent 回复（双语卡片）                                                           |
+| `/lang`                                | 打开交互式设置菜单，每个选项都有一行说明                                              |
+| `/lang check off` \| `on` \| `context` | 检查与辅导的模式——`context` 让检查能看到会话内容（`/lang on`/`off` 仍可作为快捷开关） |
+| `/lang tutor on` \| `off`              | 单独开关写作辅导（关闭后母语消息不再显示面板）                                        |
+| `/lang auto on` \| `off`               | 自动翻译每轮最终回复                                                                  |
+| `/lang native <code>`                  | 设置母语，即译文和讲解使用的语言（`zh-CN`、`ja`…）                                    |
+| `/lang learning <code>`                | 设置正在学习的语言（`en`、`fr`…）                                                     |
+| `/lang model [model]`                  | 指定本插件使用的模型                                                                  |
+| `/lang model default`                  | 换回会话模型                                                                          |
+| `/lang context on` \| `off`            | 翻译时携带完整会话上下文（默认关闭，详见下文）                                        |
 
 ## 配置
 
@@ -95,7 +95,7 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
   "learning": "en",
   "native": "zh-CN",
   "model": "openai/gpt-4o-mini",
-  "enabled": true,
+  "check": "on",
   "auto": false,
   "context": false
 }
@@ -117,6 +117,8 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 - 只有翻译使用**会话模型**时才划算——用 `/lang model` 指定了别的模型就无法命中主会话的缓存，每次翻译都会按全价重新计费整段历史。这也会改变数据的去向：指定其他模型后，发给该服务商的是整段对话，而不只是被翻译的文本。扩展会在启动和切换模型时对这种组合发出提醒；运行 `/lang model default` 即可解决。
 - 会话第一轮 agent 对话之前还没有可复用的请求，此时翻译会静默回退到无上下文模式。
+
+写作检查与辅导有自己独立的上下文档位（`/lang check context`），刻意不与翻译共用开关：检查在你发出的每条消息上都会触发，开启后每次检查都要付一次缓存读取。只有当检查总把项目术语误报成错误时才值得打开——带上下文的检查能认出会话里约定的名称和造词，辅导教你表达时也会优先用它们。
 
 ## 开发
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,30 +6,15 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import type { Config } from './core.ts'
+import { normalizeStoredConfig } from './core.ts'
 
 const CONFIG_PATH = path.join(os.homedir(), '.pi', 'agent', 'language-learn.json')
 
-export const DEFAULT_CONFIG: Config = {
-  learning: 'en',
-  native: 'zh-CN',
-  enabled: true,
-  auto: false,
-  context: false,
-  tutor: true
-}
+export const DEFAULT_CONFIG: Config = normalizeStoredConfig({})
 
 export function loadConfig(): Config {
   try {
-    const raw = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8')) as Partial<Config>
-    return {
-      learning: typeof raw.learning === 'string' ? raw.learning : DEFAULT_CONFIG.learning,
-      native: typeof raw.native === 'string' ? raw.native : DEFAULT_CONFIG.native,
-      model: typeof raw.model === 'string' ? raw.model : undefined,
-      enabled: raw.enabled !== false,
-      auto: raw.auto === true,
-      context: raw.context === true,
-      tutor: raw.tutor !== false
-    }
+    return normalizeStoredConfig(JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8')))
   } catch {
     return { ...DEFAULT_CONFIG }
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -244,14 +244,6 @@ export function parseReviewResult(raw: string): ReviewResult | undefined {
 
   if (obj.mode === 'skip' || obj.skip === true) return { mode: 'skip' }
 
-  // A JSON object with none of the review fields is not a review result at
-  // all (e.g. a forked replay where the agent prompt won and the model
-  // answered with unrelated JSON). Reject it so the caller treats it like
-  // garbage — for forked reviews that means retrying context-free.
-  if (obj.mode !== 'check' && !Array.isArray(obj.items) && obj.rephrase === undefined) {
-    return undefined
-  }
-
   // mode "check" (default — also tolerates responses that omit "mode")
   const items = Array.isArray(obj.items)
     ? obj.items.filter(
@@ -265,6 +257,19 @@ export function parseReviewResult(raw: string): ReviewResult | undefined {
     : []
   const rephrase =
     typeof obj.rephrase === 'string' && obj.rephrase.trim().length > 0 ? obj.rephrase.trim() : null
+
+  // Without an explicit mode, accept only genuine review evidence: an empty
+  // items array (legacy clean result), at least one well-formed item, or a
+  // string/null rephrase. Unrelated JSON that merely contains an items array
+  // (a forked replay where the agent prompt won) is rejected so the caller
+  // treats it like garbage — for forked reviews that means retrying
+  // context-free.
+  if (obj.mode !== 'check') {
+    const itemsEvidence = Array.isArray(obj.items) && (obj.items.length === 0 || items.length > 0)
+    const rephraseEvidence = typeof obj.rephrase === 'string' || obj.rephrase === null
+    if (!itemsEvidence && !rephraseEvidence) return undefined
+  }
+
   return { mode: 'check', items: items.slice(0, 5), rephrase }
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -244,6 +244,14 @@ export function parseReviewResult(raw: string): ReviewResult | undefined {
 
   if (obj.mode === 'skip' || obj.skip === true) return { mode: 'skip' }
 
+  // A JSON object with none of the review fields is not a review result at
+  // all (e.g. a forked replay where the agent prompt won and the model
+  // answered with unrelated JSON). Reject it so the caller treats it like
+  // garbage — for forked reviews that means retrying context-free.
+  if (obj.mode !== 'check' && !Array.isArray(obj.items) && obj.rephrase === undefined) {
+    return undefined
+  }
+
   // mode "check" (default — also tolerates responses that omit "mode")
   const items = Array.isArray(obj.items)
     ? obj.items.filter(

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,16 +4,43 @@
  * plain values (see test.mjs).
  */
 
+/** Review state: disabled, context-free, or forking the session into each review. */
+export type CheckMode = 'off' | 'on' | 'context'
+
 export interface Config {
   learning: string
   native: string
   model?: string
-  enabled: boolean
+  /** Writing check & tutor mode. 'context' costs a session cache read on every reviewed message. */
+  check: CheckMode
   auto: boolean
   /** Fork the main session's context into translation calls (default off: costs cache reads). */
   context: boolean
   /** Teach native-language prompts via the writing tutor (default on; off restores check-only). */
   tutor: boolean
+}
+
+/**
+ * Normalize a stored config object (pure, testable). Accepts the legacy
+ * `enabled: boolean` field from configs written before the writing check
+ * became tri-state.
+ */
+export function normalizeStoredConfig(raw: Partial<Config> & { enabled?: boolean }): Config {
+  const check: CheckMode =
+    raw.check === 'off' || raw.check === 'on' || raw.check === 'context'
+      ? raw.check
+      : raw.enabled === false
+        ? 'off'
+        : 'on'
+  return {
+    learning: typeof raw.learning === 'string' ? raw.learning : 'en',
+    native: typeof raw.native === 'string' ? raw.native : 'zh-CN',
+    model: typeof raw.model === 'string' ? raw.model : undefined,
+    check,
+    auto: raw.auto === true,
+    context: raw.context === true,
+    tutor: raw.tutor !== false
+  }
 }
 
 export interface GrammarItem {
@@ -136,7 +163,10 @@ export function shouldSkipCheck(text: string): boolean {
   return words.length > 0 && codey / words.length > 0.3
 }
 
-export function buildReviewPrompt(text: string, cfg: Config): string {
+export const CHECK_CONTEXT_PREFACE =
+  'The conversation above is the session this message was typed in — treat terms it establishes (project names, identifiers, coined words) as correct vocabulary, not errors, and prefer them when teaching how to express the message.'
+
+export function buildReviewPrompt(text: string, cfg: Config, contextual = false): string {
   const tutorBranch = cfg.tutor
     ? [
         `If the message is NOT primarily written in ${cfg.learning} — e.g. it is in ${cfg.native} or another language (mode "tutor") — the student could not express it in ${cfg.learning}; teach them how:`,
@@ -157,6 +187,7 @@ export function buildReviewPrompt(text: string, cfg: Config): string {
       ]
     : []
   return [
+    ...(contextual ? [CHECK_CONTEXT_PREFACE] : []),
     `You are a ${cfg.learning} language tutor. The student's native language is ${cfg.native}.`,
     `The student typed the following message to an AI coding assistant. Decide which mode applies, then respond accordingly.`,
     ``,

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -12,12 +12,18 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 import { Container, Text } from '@earendil-works/pi-tui'
 import { loadConfig } from './config.ts'
-import type { Config, GrammarItem } from './core.ts'
+import type { Config, GrammarItem, ReviewResult } from './core.ts'
 import { buildReviewPrompt, parseReviewResult, shouldSkipCheck } from './core.ts'
+import type { ForkContext } from './llm.ts'
 import { resolveModel, runLlm } from './llm.ts'
 import { showTutorWidget } from './tutor.ts'
 
 const WIDGET_KEY = 'language-learn'
+
+export interface ReviewDeps {
+  /** Fork of the main session's last LLM request (see createForkTracker). */
+  makeFork(ctx: ExtensionContext): ForkContext | undefined
+}
 
 function showCheckWidget(
   ctx: ExtensionContext,
@@ -39,7 +45,10 @@ function showCheckWidget(
 }
 
 /** Wire up the review. Returns `disable` for the settings toggle to call. */
-export function registerReview(pi: ExtensionAPI): { disable(ctx: ExtensionContext): void } {
+export function registerReview(
+  pi: ExtensionAPI,
+  deps: ReviewDeps
+): { disable(ctx: ExtensionContext): void } {
   let abort: AbortController | undefined
 
   const runReview = async (
@@ -52,11 +61,33 @@ export function registerReview(pi: ExtensionAPI): { disable(ctx: ExtensionContex
       const model = resolveModel(ctx, cfg)
       if (!model) return
 
-      const raw = await runLlm(ctx, model, buildReviewPrompt(text, cfg), signal)
-      if (signal.aborted || raw === undefined) return
+      const attempt = async (fork?: ForkContext): Promise<ReviewResult | undefined> => {
+        const raw = await runLlm(ctx, model, buildReviewPrompt(text, cfg, !!fork), signal, fork)
+        if (raw === undefined) return undefined
+        const parsed = parseReviewResult(raw)
+        // A forked reply that isn't the review JSON (the replayed agent
+        // prompt won and the model answered as the agent) is a fork failure,
+        // not a clean review; context-free garbage keeps the clear-widget
+        // behavior below.
+        if (parsed === undefined && fork) return undefined
+        return parsed ?? { mode: 'skip' }
+      }
 
-      const result = parseReviewResult(raw)
-      if (!result || result.mode === 'skip') {
+      // Context mode must be strictly additive: a fork replay can fail in
+      // ways a plain request can't (the model answers with a tool call or
+      // as the agent in prose, the provider rejects the replayed prefix),
+      // so on failure retry context-free.
+      const fork = cfg.check === 'context' ? deps.makeFork(ctx) : undefined
+      let result: ReviewResult | undefined
+      try {
+        result = await attempt(fork)
+      } catch (err) {
+        if (!fork || signal.aborted) throw err
+      }
+      if (result === undefined && fork && !signal.aborted) result = await attempt(undefined)
+      if (signal.aborted || result === undefined) return
+
+      if (result.mode === 'skip') {
         ctx.ui.setWidget(WIDGET_KEY, undefined)
         return
       }
@@ -90,7 +121,7 @@ export function registerReview(pi: ExtensionAPI): { disable(ctx: ExtensionContex
     if (!ctx.hasUI || ctx.mode !== 'tui') return
 
     const cfg = loadConfig()
-    if (!cfg.enabled) return
+    if (cfg.check === 'off') return
 
     const text = event.text.trim()
     if (shouldSkipCheck(text)) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { registerTranslation } from './translate.ts'
 
 export default function (pi: ExtensionAPI) {
   const fork = createForkTracker(pi)
-  const review = registerReview(pi)
+  const review = registerReview(pi, fork)
   registerTranslation(pi, fork)
   registerLangSettings(pi, { disableReview: review.disable })
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,14 +25,15 @@ export const STATUS_KEY = 'language-learn'
 export function updateStatus(ctx: ExtensionContext, cfg: Config): void {
   if (!ctx.hasUI) return
   const parts: string[] = []
-  if (!cfg.enabled) parts.push('✏ lang off')
+  if (cfg.check === 'off') parts.push('✏ lang off')
   if (cfg.auto) parts.push('🌐 auto')
   ctx.ui.setStatus(STATUS_KEY, parts.length > 0 ? parts.join('  ') : undefined)
 }
 
 /** Warn when a model override defeats the whole point of context mode. */
 export function warnOnCacheMismatch(ctx: ExtensionContext, cfg: Config): void {
-  if (!cfg.context || !cfg.model || cfg.model === 'default' || !ctx.model) return
+  const wantsContext = cfg.context || cfg.check === 'context'
+  if (!wantsContext || !cfg.model || cfg.model === 'default' || !ctx.model) return
   const sessionModel = `${ctx.model.provider}/${ctx.model.id}`
   // A hand-edited config may hold a bare id or a differently-cased ref that
   // still resolves to the session model; compare resolved identities, not
@@ -48,8 +49,14 @@ export function warnOnCacheMismatch(ctx: ExtensionContext, cfg: Config): void {
       ? `${match.model.provider}/${match.model.id}`
       : cfg.model
   if (override === sessionModel) return
+  // Name the features actually running with context — a check-only warning
+  // must not claim the cost is per translation.
+  const contextual = [
+    ...(cfg.context ? ['translations'] : []),
+    ...(cfg.check === 'context' ? ['writing checks'] : [])
+  ].join(' and ')
   ctx.ui.notify(
-    `/lang model is ${override} but the session model is ${sessionModel} — context-mode translations can't reuse the session's prompt cache, so the whole history is re-billed at full input price on every translation, and the entire conversation (not just the translated text) is sent to ${override}'s provider. Run "/lang model default" to follow the session model.`,
+    `/lang model is ${override} but the session model is ${sessionModel} — context-mode ${contextual} can't reuse the session's prompt cache, so the whole history is re-billed at full input price on every one, and the entire conversation (not just the processed text) is sent to ${override}'s provider. Run "/lang model default" to follow the session model.`,
     'warning'
   )
 }
@@ -96,7 +103,7 @@ async function openModelPicker(ctx: ExtensionContext, cfg: Config): Promise<void
 }
 
 const LANG_USAGE =
-  'Usage: /lang  (settings menu)  |  /lang on|off  |  /lang auto|context|tutor on|off  |  /lang native|learning <code>  |  /lang model [provider/id|id|default]'
+  'Usage: /lang  (settings menu)  |  /lang check off|on|context (on|off works bare)  |  /lang auto|context|tutor on|off  |  /lang native|learning <code>  |  /lang model [provider/id|id|default]'
 
 const LANGUAGE_PRESETS: ReadonlyArray<{ code: string; name: string }> = [
   { code: 'en', name: 'English' },
@@ -113,6 +120,7 @@ const LANGUAGE_PRESETS: ReadonlyArray<{ code: string; name: string }> = [
 const CUSTOM_LANG = '__custom__'
 
 const LANG_VALUE_COMPLETIONS: Record<string, string[]> = {
+  check: ['off', 'on', 'context'],
   auto: ['on', 'off'],
   context: ['on', 'off'],
   tutor: ['on', 'off'],
@@ -128,17 +136,23 @@ export interface SettingsDeps {
 
 /** Register the /lang command, its settings menu, and the session_start status/warning. */
 export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void {
-  /** Apply a `check`/`auto`/`context`/`tutor` toggle; shared by the menu and the direct command. */
+  /** Apply the review mode; shared by the menu and the direct command. */
+  const applyCheckMode = (ctx: ExtensionContext, cfg: Config, mode: Config['check']) => {
+    cfg.check = mode
+    if (mode === 'off') deps.disableReview(ctx)
+    if (mode === 'context') warnOnCacheMismatch(ctx, cfg)
+    saveConfig(cfg)
+    updateStatus(ctx, cfg)
+  }
+
+  /** Apply an `auto`/`context`/`tutor` toggle; shared by the menu and the direct command. */
   const applyToggle = (
     ctx: ExtensionContext,
     cfg: Config,
-    key: 'check' | 'auto' | 'context' | 'tutor',
+    key: 'auto' | 'context' | 'tutor',
     on: boolean
   ) => {
-    if (key === 'check') {
-      cfg.enabled = on
-      if (!on) deps.disableReview(ctx)
-    } else if (key === 'tutor') {
+    if (key === 'tutor') {
       cfg.tutor = on
       // The shared widget may be showing a tutor panel right now; clear it.
       if (!on) deps.disableReview(ctx)
@@ -245,10 +259,10 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
         {
           id: 'check',
           label: 'Writing check & tutor',
-          currentValue: cfg.enabled ? 'on' : 'off',
-          values: ['on', 'off'],
+          currentValue: cfg.check,
+          values: ['off', 'on', 'context'],
           description:
-            'Review prompts in your learning language (spelling/grammar) and teach prompts in your native language (words, grammar, whole-sentence expression) while the agent works'
+            'Review learning-language prompts (spelling/grammar) and teach native-language ones (words, grammar, expression) while the agent works — "context" lets the review see the conversation (session terms stop being flagged; costs a cache read per reviewed message)'
         },
         {
           id: 'tutor',
@@ -306,7 +320,9 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
         items.length + 2,
         getSettingsListTheme(),
         (id, newValue) => {
-          if (id === 'check' || id === 'auto' || id === 'context' || id === 'tutor') {
+          if (id === 'check') {
+            applyCheckMode(ctx, cfg, newValue as Config['check'])
+          } else if (id === 'auto' || id === 'context' || id === 'tutor') {
             applyToggle(ctx, cfg, id, newValue === 'on')
           } else if (id === 'native' || id === 'learning') {
             cfg[id] = newValue
@@ -344,9 +360,17 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
         )
         return values.length > 0 ? values.map((v) => ({ value: `${key} ${v}`, label: v })) : null
       }
-      const keys = ['on', 'off', 'auto', 'context', 'tutor', 'native', 'learning', 'model'].filter(
-        (k) => k.startsWith(prefix.trim().toLowerCase())
-      )
+      const keys = [
+        'on',
+        'off',
+        'check',
+        'auto',
+        'context',
+        'tutor',
+        'native',
+        'learning',
+        'model'
+      ].filter((k) => k.startsWith(prefix.trim().toLowerCase()))
       return keys.length > 0
         ? keys.map((k) => ({ value: k === 'on' || k === 'off' ? k : `${k} `, label: k }))
         : null
@@ -357,7 +381,7 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
 
       const show = () =>
         ctx.ui.notify(
-          `learning=${cfg.learning}  native=${cfg.native}  model=${cfg.model ?? 'default (session model)'}  check=${cfg.enabled ? 'on' : 'off'}  tutor=${cfg.tutor ? 'on' : 'off'}  auto=${cfg.auto ? 'on' : 'off'}  context=${cfg.context ? 'on' : 'off'}`,
+          `learning=${cfg.learning}  native=${cfg.native}  model=${cfg.model ?? 'default (session model)'}  check=${cfg.check}  tutor=${cfg.tutor ? 'on' : 'off'}  auto=${cfg.auto ? 'on' : 'off'}  context=${cfg.context ? 'on' : 'off'}`,
           'info'
         )
 
@@ -373,7 +397,14 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
       switch (sub) {
         case 'on':
         case 'off':
-          applyToggle(ctx, cfg, 'check', sub === 'on')
+          applyCheckMode(ctx, cfg, sub)
+          break
+        case 'check':
+          if (value !== 'on' && value !== 'off' && value !== 'context') {
+            ctx.ui.notify('Usage: /lang check off|on|context', 'warning')
+            return
+          }
+          applyCheckMode(ctx, cfg, value)
           break
         case 'auto':
         case 'context':

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -616,6 +616,23 @@ describe('warnOnCacheMismatch', () => {
     )
     expect(notes).toEqual([])
   })
+  it('names translations when only translation context is on', () => {
+    const notes: string[] = []
+    warnOnCacheMismatch(ctx(notes), lang('glm-5', true) as never)
+    expect(notes[0]).toContain('context-mode translations')
+    expect(notes[0]).not.toContain('writing checks')
+  })
+  it('names writing checks when only check context is on', () => {
+    const notes: string[] = []
+    warnOnCacheMismatch(ctx(notes), { ...lang('glm-5', false), check: 'context' } as never)
+    expect(notes[0]).toContain('context-mode writing checks')
+    expect(notes[0]).not.toContain('translations')
+  })
+  it('names both when translation and check context are on', () => {
+    const notes: string[] = []
+    warnOnCacheMismatch(ctx(notes), { ...lang('glm-5', true), check: 'context' } as never)
+    expect(notes[0]).toContain('translations and writing checks')
+  })
 })
 
 describe('resolveStoredModelReference (saved config refs)', () => {

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -161,6 +161,19 @@ describe('parseReviewResult', () => {
   it('non-review JSON (no mode/items/rephrase) is rejected, not treated as a clean check', () => {
     expect(parseReviewResult('{"name": "pkg", "version": "1.0.0"}')).toBeUndefined()
   })
+  it('mode-less JSON whose items are not review items is rejected too', () => {
+    expect(parseReviewResult('{"items": [{"name": "pkg", "version": "1.0.0"}]}')).toBeUndefined()
+  })
+  it('mode-less object with an empty items array still parses as a legacy clean check', () => {
+    expect(parseReviewResult('{"items": []}')).toEqual({ mode: 'check', items: [], rephrase: null })
+  })
+  it('mode-less object with one well-formed item still parses as check', () => {
+    expect(parseReviewResult('{"items": [{"wrong":"a","right":"b","reason":"c"}]}')).toEqual({
+      mode: 'check',
+      items: [{ wrong: 'a', right: 'b', reason: 'c' }],
+      rephrase: null
+    })
+  })
   it('mode-less object with only rephrase still parses as check', () => {
     expect(parseReviewResult('{"rephrase": "Better phrasing."}')).toEqual({
       mode: 'check',

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -7,7 +7,9 @@ import {
   cardMarkdown,
   buildSegmentPrompt,
   buildWholeTranslatePrompt,
+  CHECK_CONTEXT_PREFACE,
   CONTEXT_PREFACE,
+  normalizeStoredConfig,
   resolveModelReference,
   resolveStoredModelReference
 } from '../language-learn.ts'
@@ -241,7 +243,7 @@ describe('buildReviewPrompt', () => {
   const cfg = {
     learning: 'en',
     native: 'zh-CN',
-    enabled: true,
+    check: 'on' as const,
     auto: false,
     context: false,
     tutor: true
@@ -286,11 +288,18 @@ describe('prompt builders', () => {
   const cfg = {
     learning: 'en',
     native: 'zh-CN',
-    enabled: true,
+    check: 'on' as const,
     auto: false,
     context: false,
     tutor: true
   }
+
+  it('review prompt has no context preface by default', () => {
+    expect(buildReviewPrompt('some text', cfg)).not.toContain(CHECK_CONTEXT_PREFACE)
+  })
+  it('contextual review prompt starts with the check preface', () => {
+    expect(buildReviewPrompt('some text', cfg, true).startsWith(CHECK_CONTEXT_PREFACE)).toBe(true)
+  })
 
   it('segment prompt numbers segments and pins the count', () => {
     const sp = buildSegmentPrompt(['a', 'b'], cfg)
@@ -508,10 +517,35 @@ const lang = (model?: string, context = false) => ({
   learning: 'en',
   native: 'zh-CN',
   model,
-  enabled: true,
+  check: 'on' as const,
   auto: false,
   context,
   tutor: true
+})
+
+describe('normalizeStoredConfig', () => {
+  it('defaults to check on', () => {
+    expect(normalizeStoredConfig({}).check).toBe('on')
+  })
+  it('migrates legacy enabled: false to check off', () => {
+    expect(normalizeStoredConfig({ enabled: false }).check).toBe('off')
+  })
+  it('migrates legacy enabled: true to check on', () => {
+    expect(normalizeStoredConfig({ enabled: true }).check).toBe('on')
+  })
+  it('keeps an explicit tri-state check value', () => {
+    expect(normalizeStoredConfig({ check: 'context' }).check).toBe('context')
+  })
+  it('an explicit check value wins over a stale legacy enabled flag', () => {
+    expect(normalizeStoredConfig({ check: 'context', enabled: false }).check).toBe('context')
+  })
+  it('rejects an invalid check value back to the default', () => {
+    expect(normalizeStoredConfig({ check: 'sometimes' as never }).check).toBe('on')
+  })
+  it('defaults tutor to on and keeps an explicit tutor: false', () => {
+    expect(normalizeStoredConfig({}).tutor).toBe(true)
+    expect(normalizeStoredConfig({ tutor: false }).tutor).toBe(false)
+  })
 })
 
 describe('resolveModel (pi CLI semantics over available/catalog)', () => {

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -158,6 +158,16 @@ describe('parseReviewResult', () => {
   it('garbage', () => {
     expect(parseReviewResult('I cannot help with that')).toBeUndefined()
   })
+  it('non-review JSON (no mode/items/rephrase) is rejected, not treated as a clean check', () => {
+    expect(parseReviewResult('{"name": "pkg", "version": "1.0.0"}')).toBeUndefined()
+  })
+  it('mode-less object with only rephrase still parses as check', () => {
+    expect(parseReviewResult('{"rephrase": "Better phrasing."}')).toEqual({
+      mode: 'check',
+      items: [],
+      rephrase: 'Better phrasing.'
+    })
+  })
   it('truncated json', () => {
     expect(parseReviewResult('{"mode": "check", "items": [{"wrong": "a"')).toBeUndefined()
   })


### PR DESCRIPTION
## Summary
- `Config.enabled: boolean` → `check: 'off' | 'on' | 'context'`. `off`/`on` behave exactly as before; `context` forks the main session's last LLM request into each check (the same prompt-cache replay translations use), so project names, identifiers, and coined words the session established stop being flagged as spelling errors.
- New command `/lang check off|on|context`; `/lang on`/`/lang off` remain as shortcuts. The settings-menu Writing check entry cycles three values.
- Fork replay is strictly additive: if the contextual check fails (tool-call answer, rejected prefix), it retries context-free — mirroring translate's existing fallback.
- `warnOnCacheMismatch` now also fires for `check: 'context'` + a model override, since a contextual check can't reuse the session cache across models either.
- Legacy configs migrate transparently: `enabled: true/false` maps to `on`/`off` in a pure, unit-tested `normalizeStoredConfig`.

## Why a tri-state, and why separate from `/lang context`
`off`/`on`/`context` are mutually exclusive positions of one dial — an enum makes the illegal "disabled but contextual" state unrepresentable, where a second boolean would introduce it. It stays separate from translation's context switch because the cost profiles differ: checks fire on **every message** (one cache read each), translation context is per-⌥T. A shared switch would silently couple the cheap choice to the expensive one. Translation's `auto`/`context` remain two booleans on purpose — they are orthogonal and all four combinations are valid.

## Verification
- `npm run check` passes; `npm test` 81/81 (18 new: config migration matrix, contextual grammar prompt preface, existing suites updated)
- `npm run lint`: 0 errors (1 pre-existing warning); `npm run fmt:check` clean
- READMEs updated in both languages (settings table, config example, context-mode section)