### PR TITLE
feat(lang): add Writing tutor for native-language prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 English | [简体中文](README.zh-CN.md)
 
-Learn a foreign language while you code. A [pi](https://pi.dev) extension that reviews your prompts for spelling, grammar, and natural phrasing — with explanations in your native language — and renders agent replies as bilingual immersive translations.
+Learn a foreign language while you code. A [pi](https://pi.dev) extension that reviews your prompts for spelling, grammar, and natural phrasing — with explanations in your native language — teaches you how to express thoughts you couldn't yet say in the learning language, and renders agent replies as bilingual immersive translations.
 
 <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/writing-check.png" width="720" alt="The Writing check panel: while the agent works on the prompt, each mistake is shown with its fix, an explanation in your native language, and a more natural phrasing of the whole sentence.">
 
@@ -44,11 +44,19 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
    While the agent answers, a `✏ Writing check` panel appears above the editor: each mistake with its fix and a short explanation in your native language, plus a more natural phrasing of the whole sentence.
 
-2. When the agent finishes, press `alt+t` (macOS: ⌥T — [enable Option-as-Meta](https://iterm2.com/documentation-preferences-profiles-keys.html) in your terminal, or run `/translate`). The response re-renders as a bilingual card: each paragraph followed by its translation.
+2. Write a prompt in your **native** language instead — because the thought came faster that way, or you couldn't yet express it in the learning language:
+
+   ```text
+   我想重构这个函数但是不知道怎么下手
+   ```
+
+   A `✏ Writing tutor` panel appears: a natural whole-sentence rendering in the learning language, the key new words (each explained in your native language — meaning, usage, why this word over a synonym), and the grammatical structures carrying the sentence. One panel teaches you how to say what you couldn't.
+
+3. When the agent finishes, press `alt+t` (macOS: ⌥T — [enable Option-as-Meta](https://iterm2.com/documentation-preferences-profiles-keys.html) in your terminal, or run `/translate`). The response re-renders as a bilingual card: each paragraph followed by its translation.
 
    <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/bilingual-card.png" width="720" alt="The bilingual card: each paragraph of the agent's response is followed by its translation, immersive-translate style, with code blocks kept intact.">
 
-3. Like the bilingual view? Make it automatic:
+4. Like the bilingual view? Make it automatic:
 
    ```text
    /lang auto on
@@ -58,9 +66,10 @@ That is enough to start.
 
 ## What happens
 
-- **Nothing ever blocks.** Your message goes to the agent immediately; the writing check runs in parallel and the panel appears a moment later. A clean message shows no panel at all.
+- **Nothing ever blocks.** Your message goes to the agent immediately; the review runs in parallel and the panel appears a moment later. A clean message shows no panel at all.
+- **Two complementary panels, never both.** Prompt in the learning language → `✏ Writing check` fixes your mistakes. Prompt in your native language → `✏ Writing tutor` teaches you the words, grammar, and whole-sentence expression. One LLM call decides which — they never both fire.
 - **Nothing pollutes the conversation.** Translation cards live only in your terminal — they are never sent back to the LLM and cost no context.
-- **You control the spend.** Both features use your session model by default; point them at a cheaper one with `/lang model` and every check becomes nearly free.
+- **You control the spend.** All features use your session model by default; point them at a cheaper one with `/lang model` and every review becomes nearly free.
 
 ## Settings
 
@@ -70,7 +79,7 @@ Type `/lang` in the TUI to open the interactive settings menu, or set things dir
 | --------------------------- | ----------------------------------------------------------------------------------------- |
 | `/translate` or `alt+t`     | Translate the last assistant response (bilingual card)                                    |
 | `/lang`                     | Open the interactive settings menu — every option with an inline description              |
-| `/lang on` \| `off`         | Resume / pause the writing check                                                          |
+| `/lang on` \| `off`         | Resume / pause the writing check & tutor                                                  |
 | `/lang auto on` \| `off`    | Auto-translate every final response                                                       |
 | `/lang native <code>`       | Set your native language — translation target and explanation language (`zh-CN`, `ja`, …) |
 | `/lang learning <code>`     | Set the language you are practicing (`en`, `fr`, …)                                       |
@@ -97,7 +106,9 @@ Settings persist in `~/.pi/agent/language-learn.json`.
 
 ## Details
 
-**What gets checked.** To avoid wasted tokens and noise, the writing check skips: slash/bang commands, messages under 4 words, messages that are mostly code or paths, messages not written in the learning language, and everything while `/lang off`. Checks run only in interactive TUI mode, and a failed check never disturbs your session.
+**What gets reviewed.** To avoid wasted tokens and noise, the review skips: slash/bang commands, trivially short prompts, messages that are mostly code or paths, and everything while `/lang off`. CJK prompts are counted by characters, not whitespace words, so a substantial native-language prompt still reaches the tutor. Reviews run only in interactive TUI mode, and a failed review never disturbs your session.
+
+**Writing check vs. Writing tutor.** A single LLM call inspects each prompt and picks a mode. If the prompt is in your learning language, it reviews spelling, grammar, and phrasing (the `✏ Writing check` panel). If the prompt is in your native language — you couldn't yet express it in the learning language — it teaches instead (the `✏ Writing tutor` panel): a natural whole-sentence rendering, the key new vocabulary (each explained in your native language), and the grammatical structures at work. The two are complementary and never both fire on the same prompt.
 
 **Bilingual cards.** Paragraphs are aligned original-then-translation, immersive-translate style. Short code blocks (≤5 lines) are kept in the card; longer ones become a `[code block ↑ N lines]` placeholder since the original sits right above. Auto mode skips intermediate tool-call narration and responses under ~15 words; the footer shows `🌐 auto` while enabled.
 
@@ -116,4 +127,4 @@ npm run check   # typecheck
 npm test        # unit tests for the skip heuristics and response parsing
 ```
 
-Layout: `src/core.ts` holds the pure logic (heuristics, prompts, parsing, card assembly — what the tests import, zero pi imports) and `src/config.ts` the config persistence. The pi-facing side is split by feature: `src/llm.ts` (model resolution, LLM calls, session-fork tracking), `src/grammar.ts` (writing check), `src/translate.ts` (bilingual cards), `src/settings.ts` (`/lang` command and menu), with `src/index.ts` as the composition root wiring them together. `language-learn.ts` is the entry point re-exporting core and the default export.
+Layout: `src/core.ts` holds the pure logic (heuristics, prompts, parsing, card assembly — what the tests import, zero pi imports) and `src/config.ts` the config persistence. The pi-facing side is split by feature: `src/llm.ts` (model resolution, LLM calls, session-fork tracking), `src/grammar.ts` (the unified review: writing check + writing tutor dispatch), `src/tutor.ts` (the writing tutor renderer), `src/translate.ts` (bilingual cards), `src/settings.ts` (`/lang` command and menu), with `src/index.ts` as the composition root wiring them together. `language-learn.ts` is the entry point re-exporting core and the default export.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | 简体中文
 
-一边 coding 一边学外语。这是一个 [pi](https://pi.dev) 扩展：它会检查你 prompt 里的拼写和语法，用母语给你讲解错在哪，还能把 agent 的回复渲染成沉浸式翻译那样的双语对照。
+一边 coding 一边学外语。这是一个 [pi](https://pi.dev) 扩展：检查你 prompt 里的拼写和语法并用母语讲解错在哪；当你用母语写下还不会用学习语言表达的句子时，教你怎么说——给出整句地道说法、关键词汇和语法点；还能把 agent 的回复渲染成沉浸式翻译那样的双语对照。
 
 <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/writing-check.png" width="720" alt="Writing check 面板：agent 照常处理 prompt 的同时，每个错误都给出改法、中文解释，以及整句更地道的说法。">
 
@@ -42,11 +42,19 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
    agent 照常回答；与此同时编辑器上方会出现 `✏ Writing check` 面板，列出每处错误的改法和中文讲解，最后还有一句整体更地道的表达。
 
-2. agent 回答完，按 `alt+t`（macOS 上是 ⌥T，需要在终端里[把 Option 设为 Meta 键](https://iterm2.com/documentation-preferences-profiles-keys.html)；也可以直接运行 `/translate`）。回复会重新渲染成双语卡片，每个原文段落下面紧跟译文。
+2. 换成用**母语**写 prompt——可能是因为这么想更快，也可能是因为还不会用学习语言表达：
+
+   ```text
+   我想重构这个函数但是不知道怎么下手
+   ```
+
+   这次出现的是 `✏ Writing tutor` 面板：先给你一句地道的学习语言整句表达，再列出关键的新词（每个都用母语讲解——意思、用法、为什么选这个词而不是别的），最后是这句话里的语法点。一个面板把你不会说的那句话讲明白。
+
+3. agent 回答完，按 `alt+t`（macOS 上是 ⌥T，需要在终端里[把 Option 设为 Meta 键](https://iterm2.com/documentation-preferences-profiles-keys.html)；也可以直接运行 `/translate`）。回复会重新渲染成双语卡片，每个原文段落下面紧跟译文。
 
    <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/bilingual-card.png" width="720" alt="双语卡片：agent 回复的每个段落下面紧跟译文，沉浸式翻译风格，代码块原样保留。">
 
-3. 觉得双语对照好用，可以让每条回复自动翻译：
+4. 觉得双语对照好用，可以让每条回复自动翻译：
 
    ```text
    /lang auto on
@@ -56,9 +64,10 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 ## 工作机制
 
-- **绝不阻塞。** 消息照常立刻发给 agent，写作检查在后台并行跑，面板稍后才出现；没写错就什么都不显示。
+- **绝不阻塞。** 消息照常立刻发给 agent，检查在后台并行跑，面板稍后才出现；没写错就什么都不显示。
+- **两个互补的面板，不会同时出现。** 用学习语言写 → `✏ Writing check` 帮你改错。用母语写 → `✏ Writing tutor` 教你词汇、语法和整句表达。一次 LLM 调用决定走哪个分支，二者绝不会同时触发。
 - **绝不污染对话。** 翻译卡片只显示在你的终端里，不会发回给 LLM，也不占上下文。
-- **花费你说了算。** 两个功能默认用当前会话的模型；用 `/lang model` 换个便宜模型，每次检查的成本就小到可以忽略。
+- **花费你说了算。** 所有功能默认用当前会话的模型；用 `/lang model` 换个便宜模型，每次检查的成本就小到可以忽略。
 
 ## 设置
 
@@ -68,7 +77,7 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 | --------------------------- | -------------------------------------------------- |
 | `/translate` 或 `alt+t`     | 翻译 agent 回复（双语卡片）                        |
 | `/lang`                     | 打开交互式设置菜单，每个选项都有一行说明           |
-| `/lang on` \| `off`         | 恢复/暂停写作检查                                  |
+| `/lang on` \| `off`         | 恢复/暂停写作检查与写作辅导                        |
 | `/lang auto on` \| `off`    | 自动翻译每轮最终回复                               |
 | `/lang native <code>`       | 设置母语，即译文和讲解使用的语言（`zh-CN`、`ja`…） |
 | `/lang learning <code>`     | 设置正在学习的语言（`en`、`fr`…）                  |
@@ -95,7 +104,9 @@ ln -s "$(pwd)/pi-language-tutor" ~/.pi/agent/extensions/pi-language-tutor
 
 ## 更多细节
 
-**哪些消息会被检查。** 为了省 token、少打扰，以下消息不会触发写作检查：斜杠/感叹号命令、少于 4 个词的短消息、以代码或路径为主的消息、没用学习语言写的消息，以及 `/lang off` 期间的所有输入。检查只在交互式 TUI 里运行；就算检查失败，也不会影响你的会话。
+**哪些消息会被检查。** 为了省 token、少打扰，以下消息不会触发检查：斜杠/感叹号命令、过短的消息、以代码或路径为主的消息，以及 `/lang off` 期间的所有输入。CJK 文本按字符数计算（而不是按空格分词），所以用母语写的一整句仍然会进入写作辅导。检查只在交互式 TUI 里运行；就算检查失败，也不会影响你的会话。
+
+**Writing check 与 Writing tutor。** 每条消息只发一次 LLM 调用，由模型选择模式。如果消息是学习语言写的，检查拼写、语法和表达（`✏ Writing check` 面板）。如果消息是母语写的——也就是说你还不会用学习语言表达——就改为教学（`✏ Writing tutor` 面板）：一句地道的整句表达，需要学的关键词汇（每个都用母语讲解），以及句中的语法结构。两者互补，绝不会在同一条消息上同时出现。
 
 **双语卡片。** 段落按「原文在上、译文在下」排列，和沉浸式翻译一个风格。短代码块（≤5 行）原样保留，更长的用 `[code block ↑ N lines]` 占位——完整代码就在上方的原文里。自动模式下，中间的工具调用叙述和少于 15 个词的回复不会翻译；开启时底部状态栏会显示 `🌐 auto`。
 
@@ -114,4 +125,4 @@ npm run check   # 类型检查
 npm test        # 单元测试：跳过判定和回复解析
 ```
 
-目录结构：`src/core.ts` 放纯逻辑（跳过判定、prompt、解析、卡片拼装，测试只依赖这个文件，不 import 任何 pi 包），`src/config.ts` 负责配置读写。pi 适配层按特性拆分：`src/llm.ts`（模型解析、LLM 调用、会话 fork 捕获）、`src/grammar.ts`（写作检查）、`src/translate.ts`（双语卡片）、`src/settings.ts`（`/lang` 命令和设置菜单），`src/index.ts` 是组装根，把它们接到 pi 上。`language-learn.ts` 是入口，重新导出核心模块。
+目录结构：`src/core.ts` 放纯逻辑（跳过判定、prompt、解析、卡片拼装，测试只依赖这个文件，不 import 任何 pi 包），`src/config.ts` 负责配置读写。pi 适配层按特性拆分：`src/llm.ts`（模型解析、LLM 调用、会话 fork 捕获）、`src/grammar.ts`（统一的检查入口：分发 Writing check 与 Writing tutor）、`src/tutor.ts`（写作辅导的渲染）、`src/translate.ts`（双语卡片）、`src/settings.ts`（`/lang` 命令和设置菜单），`src/index.ts` 是组装根，把它们接到 pi 上。`language-learn.ts` 是入口，重新导出核心模块。

--- a/language-learn.ts
+++ b/language-learn.ts
@@ -3,7 +3,8 @@
  * - src/core.ts      — pure logic (heuristics, prompts, parsing, card assembly)
  * - src/config.ts    — config persistence
  * - src/llm.ts       — model resolution, LLM calls, session-fork tracking
- * - src/grammar.ts   — the "✏ Writing check" widget
+ * - src/grammar.ts   — the unified review: dispatches "✏ Writing check" and "✏ Writing tutor"
+ * - src/tutor.ts     — the "✏ Writing tutor" widget renderer
  * - src/translate.ts — bilingual translation cards
  * - src/settings.ts  — /lang command, settings menu, status bar
  * - src/index.ts     — composition root wiring the features together

--- a/src/core.ts
+++ b/src/core.ts
@@ -20,11 +20,35 @@ export interface GrammarItem {
   reason: string
 }
 
-export interface GrammarResult {
-  skip?: boolean
-  items?: GrammarItem[]
-  rephrase?: string | null
+/** A vocabulary item taught by the tutor: the word as used in the sentence + a note in the native language. */
+export interface TutorWord {
+  word: string
+  note: string
 }
+
+/** A grammar structure taught by the tutor: name of the structure + a note in the native language. */
+export interface TutorGrammar {
+  structure: string
+  note: string
+}
+
+/** The tutor payload: a natural rendering of the whole thought, plus the words and grammar worth learning. */
+export interface TutorResult {
+  sentence: string
+  words: TutorWord[]
+  grammar: TutorGrammar[]
+}
+
+/**
+ * One review pass over a prompt. The agent decides the mode:
+ * - `check`: the prompt is in the learning language — review it (existing writing check).
+ * - `tutor`: the prompt is in the native (or another non-learning) language — teach how to say it in the learning language.
+ * - `skip`: neither (too short, code, unclear).
+ */
+export type ReviewResult =
+  | { mode: 'check'; items: GrammarItem[]; rephrase: string | null }
+  | { mode: 'tutor'; tutor: TutorResult }
+  | { mode: 'skip' }
 
 export type Segment =
   | { kind: 'prose'; text: string }
@@ -79,38 +103,63 @@ export function extractJson<T>(raw: string): T | undefined {
 }
 
 // ---------------------------------------------------------------------------
-// Writing check
+// Review (writing check + writing tutor)
 // ---------------------------------------------------------------------------
 
+/**
+ * Should the review be skipped for this prompt? Covers slash/bang commands,
+ * trivially short prompts, code fences, symbol-heavy text, and mostly-code
+ * text. CJK text is NOT penalized for lacking spaces — a CJK sentence is
+ * counted by characters, so a substantial native-language prompt still
+ * reaches the tutor.
+ */
 export function shouldSkipCheck(text: string): boolean {
   if (text.startsWith('/') || text.startsWith('!')) return true
-  if (text.split(/\s+/).filter(Boolean).length < 4) return true
   if (text.includes('```')) return true
 
   const chars = text.replace(/\s+/g, '')
   if (chars.length === 0) return true
+
+  // Content units: whitespace-separated words for Latin scripts, plus CJK
+  // characters counted individually (CJK text is rarely space-separated).
+  // Fewer than 4 units is too short to review or tutor.
+  const words = text.split(/\s+/).filter(Boolean)
+  const cjk = text.match(/[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/gu)?.length ?? 0
+  if (Math.max(words.length, cjk) < 4) return true
+
   const letters = chars.match(/\p{L}/gu)?.length ?? 0
   if (letters / chars.length < 0.5) return true
 
-  const words = text.split(/\s+/).filter(Boolean)
   const codey = words.filter((w) => /[{}()[\];=<>\\`$]|::|->|\.[a-z]{1,4}$|\//.test(w)).length
-  return codey / words.length > 0.3
+  return words.length > 0 && codey / words.length > 0.3
 }
 
-export function buildGrammarPrompt(text: string, cfg: Config): string {
+export function buildReviewPrompt(text: string, cfg: Config): string {
   return [
-    `You are a ${cfg.learning} writing tutor. The student's native language is ${cfg.native}.`,
-    `The student typed the following message to an AI coding assistant. Check it.`,
+    `You are a ${cfg.learning} language tutor. The student's native language is ${cfg.native}.`,
+    `The student typed the following message to an AI coding assistant. Decide which mode applies, then respond accordingly.`,
     ``,
-    `Respond with ONLY a JSON object, no markdown fences, in one of these forms:`,
-    `- If the message is NOT primarily written in ${cfg.learning}, or there is nothing worth reporting: {"skip": true}`,
-    `- Otherwise: {"skip": false, "items": [{"wrong": "...", "right": "...", "reason": "..."}], "rephrase": "..."}`,
+    `Respond with ONLY a JSON object, no markdown fences:`,
+    ``,
+    `If the message IS primarily written in ${cfg.learning} (mode "check") — review it:`,
+    `  {"mode": "check", "items": [{"wrong": "...", "right": "...", "reason": "..."}], "rephrase": "..." or null}`,
+    `  - "items": genuine spelling/grammar errors only, at most 5. "wrong"/"right" are short exact fragments. "reason" is a very short explanation written in ${cfg.native}.`,
+    `  - "rephrase": only if the message is understandable but sounds noticeably non-native, give ONE more natural way to phrase it in ${cfg.learning}; otherwise null.`,
+    `  - A correct message: {"mode": "check", "items": [], "rephrase": null}.`,
+    ``,
+    `If the message is NOT primarily written in ${cfg.learning} — e.g. it is in ${cfg.native} or another language (mode "tutor") — the student could not express it in ${cfg.learning}; teach them how:`,
+    `  {"mode": "tutor", "sentence": "...", "words": [{"word": "...", "note": "..."}], "grammar": [{"structure": "...", "note": "..."}]}`,
+    `  - "sentence": a natural, idiomatic ${cfg.learning} rendering of the student's WHOLE thought (not a word-by-word gloss).`,
+    `  - "words": the key vocabulary worth learning (at most 5). "word" is the ${cfg.learning} word/phrase exactly as used in "sentence". "note" is a short explanation in ${cfg.native}: meaning, usage, register, and why this word over an obvious synonym.`,
+    `  - "grammar": the grammatical structures carrying the sentence (at most 3). "structure" names the structure (e.g. tense, mood, particle, clause shape, agreement). "note" explains in ${cfg.native} what it is and why it is used here.`,
+    `  - If the message is too short, code, or has no clear meaning to teach, return {"mode": "skip"} instead.`,
+    ``,
+    `If neither mode fits (too short, code, unclear): {"mode": "skip"}`,
     ``,
     `Rules:`,
-    `- "items": genuine spelling/grammar errors only, at most 5. "wrong"/"right" are short exact fragments. "reason" is a very short explanation written in ${cfg.native}.`,
-    `- "rephrase": only if the message is understandable but sounds noticeably non-native, give ONE more natural way to phrase it in ${cfg.learning}; otherwise use null.`,
-    `- Ignore code, file paths, identifiers, product names, and technical jargon.`,
-    `- Do not invent errors. A correct message gets {"skip": false, "items": [], "rephrase": null}.`,
+    `- Ignore code, file paths, identifiers, product names, and technical jargon — do not try to fix or translate them.`,
+    `- A message already correct in ${cfg.learning} is mode "check" with empty items, NOT "tutor".`,
+    `- Never invent errors, never invent vocabulary the student did not express.`,
     ``,
     `Message:`,
     `<<<`,
@@ -119,8 +168,51 @@ export function buildGrammarPrompt(text: string, cfg: Config): string {
   ].join('\n')
 }
 
-export function parseGrammarResult(raw: string): GrammarResult | undefined {
-  return extractJson<GrammarResult>(raw)
+export function parseReviewResult(raw: string): ReviewResult | undefined {
+  const obj = extractJson<{
+    mode?: string
+    skip?: boolean
+    items?: GrammarItem[]
+    rephrase?: string | null
+    sentence?: string
+    words?: TutorWord[]
+    grammar?: TutorGrammar[]
+  }>(raw)
+  if (!obj) return undefined
+
+  if (obj.mode === 'tutor') {
+    const sentence = typeof obj.sentence === 'string' ? obj.sentence.trim() : ''
+    const words = Array.isArray(obj.words)
+      ? obj.words.filter((w) => w && typeof w.word === 'string' && typeof w.note === 'string')
+      : []
+    const grammar = Array.isArray(obj.grammar)
+      ? obj.grammar.filter(
+          (g) => g && typeof g.structure === 'string' && typeof g.note === 'string'
+        )
+      : []
+    if (!sentence && words.length === 0 && grammar.length === 0) return { mode: 'skip' }
+    return {
+      mode: 'tutor',
+      tutor: { sentence, words: words.slice(0, 5), grammar: grammar.slice(0, 3) }
+    }
+  }
+
+  if (obj.mode === 'skip' || obj.skip === true) return { mode: 'skip' }
+
+  // mode "check" (default — also tolerates responses that omit "mode")
+  const items = Array.isArray(obj.items)
+    ? obj.items.filter(
+        (i) =>
+          i &&
+          typeof i.wrong === 'string' &&
+          i.wrong.trim().length > 0 &&
+          typeof i.right === 'string' &&
+          i.right.trim().length > 0
+      )
+    : []
+  const rephrase =
+    typeof obj.rephrase === 'string' && obj.rephrase.trim().length > 0 ? obj.rephrase.trim() : null
+  return { mode: 'check', items: items.slice(0, 5), rephrase }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -1,19 +1,25 @@
 /**
- * Writing check: watches interactive input and renders the "✏ Writing check"
- * widget above the editor. Non-blocking by design — the message reaches the
- * agent immediately and a failed check never disturbs the session.
+ * Review: watches interactive input and renders either the "✏ Writing check"
+ * widget (the prompt is in the learning language — fix mistakes) or the
+ * "✏ Writing tutor" widget (the prompt is in the native language — teach the
+ * words, grammar, and whole-sentence expression). A single LLM call decides
+ * the mode, so the two are complementary and never both fire.
+ *
+ * Non-blocking by design — the message reaches the agent immediately and a
+ * failed review never disturbs the session.
  */
 
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 import { Container, Text } from '@earendil-works/pi-tui'
 import { loadConfig } from './config.ts'
 import type { Config, GrammarItem } from './core.ts'
-import { buildGrammarPrompt, parseGrammarResult, shouldSkipCheck } from './core.ts'
+import { buildReviewPrompt, parseReviewResult, shouldSkipCheck } from './core.ts'
 import { resolveModel, runLlm } from './llm.ts'
+import { showTutorWidget } from './tutor.ts'
 
 const WIDGET_KEY = 'language-learn'
 
-function showWidget(
+function showCheckWidget(
   ctx: ExtensionContext,
   items: GrammarItem[],
   rephrase: string | undefined
@@ -32,11 +38,11 @@ function showWidget(
   })
 }
 
-/** Wire up the writing check. Returns `disable` for the settings toggle to call. */
-export function registerGrammarCheck(pi: ExtensionAPI): { disable(ctx: ExtensionContext): void } {
+/** Wire up the review. Returns `disable` for the settings toggle to call. */
+export function registerReview(pi: ExtensionAPI): { disable(ctx: ExtensionContext): void } {
   let abort: AbortController | undefined
 
-  const runCheck = async (
+  const runReview = async (
     text: string,
     cfg: Config,
     ctx: ExtensionContext,
@@ -46,23 +52,30 @@ export function registerGrammarCheck(pi: ExtensionAPI): { disable(ctx: Extension
       const model = resolveModel(ctx, cfg)
       if (!model) return
 
-      const raw = await runLlm(ctx, model, buildGrammarPrompt(text, cfg), signal)
+      const raw = await runLlm(ctx, model, buildReviewPrompt(text, cfg), signal)
       if (signal.aborted || raw === undefined) return
 
-      const result = parseGrammarResult(raw)
-      const items = result?.skip ? [] : (result?.items ?? []).filter((i) => i && i.wrong && i.right)
-      const rephrase =
-        !result?.skip && typeof result?.rephrase === 'string' && result.rephrase.trim().length > 0
-          ? result.rephrase.trim()
-          : undefined
+      const result = parseReviewResult(raw)
+      if (!result || result.mode === 'skip') {
+        ctx.ui.setWidget(WIDGET_KEY, undefined)
+        return
+      }
 
+      if (result.mode === 'tutor') {
+        showTutorWidget(ctx, result.tutor)
+        return
+      }
+
+      // check
+      const items = result.items
+      const rephrase = result.rephrase ?? undefined
       if (items.length === 0 && !rephrase) {
         ctx.ui.setWidget(WIDGET_KEY, undefined)
       } else {
-        showWidget(ctx, items.slice(0, 5), rephrase)
+        showCheckWidget(ctx, items, rephrase)
       }
     } catch {
-      // silent by design: a failed check must never disturb the session
+      // silent by design: a failed review must never disturb the session
     }
   }
 
@@ -79,7 +92,7 @@ export function registerGrammarCheck(pi: ExtensionAPI): { disable(ctx: Extension
     abort?.abort()
     abort = new AbortController()
     // Fire and forget: the message continues to the agent immediately.
-    void runCheck(text, cfg, ctx, abort.signal)
+    void runReview(text, cfg, ctx, abort.signal)
   })
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,14 @@
  */
 
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
-import { registerGrammarCheck } from './grammar.ts'
+import { registerReview } from './grammar.ts'
 import { createForkTracker } from './llm.ts'
 import { registerLangSettings } from './settings.ts'
 import { registerTranslation } from './translate.ts'
 
 export default function (pi: ExtensionAPI) {
   const fork = createForkTracker(pi)
-  const grammar = registerGrammarCheck(pi)
+  const review = registerReview(pi)
   registerTranslation(pi, fork)
-  registerLangSettings(pi, { disableGrammar: grammar.disable })
+  registerLangSettings(pi, { disableReview: review.disable })
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -121,8 +121,8 @@ const LANG_VALUE_COMPLETIONS: Record<string, string[]> = {
 }
 
 export interface SettingsDeps {
-  /** Abort any in-flight writing check and hide its widget (check turned off). */
-  disableGrammar(ctx: ExtensionContext): void
+  /** Abort any in-flight review and hide its widget (check/tutor turned off). */
+  disableReview(ctx: ExtensionContext): void
 }
 
 /** Register the /lang command, its settings menu, and the session_start status/warning. */
@@ -136,7 +136,7 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
   ) => {
     if (key === 'check') {
       cfg.enabled = on
-      if (!on) deps.disableGrammar(ctx)
+      if (!on) deps.disableReview(ctx)
     } else if (key === 'auto') {
       cfg.auto = on
       if (on && !cfg.model) {
@@ -239,10 +239,11 @@ export function registerLangSettings(pi: ExtensionAPI, deps: SettingsDeps): void
       const items: SettingItem[] = [
         {
           id: 'check',
-          label: 'Writing check',
+          label: 'Writing check & tutor',
           currentValue: cfg.enabled ? 'on' : 'off',
           values: ['on', 'off'],
-          description: 'Review your prompts for spelling and grammar while the agent works'
+          description:
+            'Review prompts in your learning language (spelling/grammar) and teach prompts in your native language (words, grammar, whole-sentence expression) while the agent works'
         },
         {
           id: 'auto',

--- a/src/tutor.ts
+++ b/src/tutor.ts
@@ -1,0 +1,56 @@
+/**
+ * Writing tutor: the renderer for the "✏ Writing tutor" widget — the sibling
+ * of "✏ Writing check". When the student writes a prompt in their native
+ * language (they couldn't express it in the learning language), this teaches
+ * them the words, grammar, and whole-sentence expression for that thought.
+ *
+ * The review dispatch (which mode to render) lives in grammar.ts; this module
+ * only renders the tutor payload.
+ */
+
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent'
+import { Container, Text } from '@earendil-works/pi-tui'
+import type { TutorResult } from './core.ts'
+
+const WIDGET_KEY = 'language-learn'
+
+export function showTutorWidget(ctx: ExtensionContext, tutor: TutorResult): void {
+  ctx.ui.setWidget(WIDGET_KEY, (_tui, theme) => {
+    const container = new Container()
+    container.addChild(new Text(theme.fg('accent', theme.bold('✏ Writing tutor')), 1, 0))
+
+    // Whole-sentence expression — the natural way to say the whole thought.
+    if (tutor.sentence) {
+      container.addChild(
+        new Text(`${theme.fg('dim', '◇')} ${theme.fg('success', tutor.sentence)}`, 1, 0)
+      )
+    }
+
+    // Key vocabulary — each word with a short note in the native language.
+    if (tutor.words.length > 0) {
+      container.addChild(new Text(theme.fg('muted', 'Words'), 1, 0))
+      for (const w of tutor.words) {
+        container.addChild(
+          new Text(`${theme.fg('accent', w.word)}  ${theme.fg('dim', w.note)}`, 1, 0)
+        )
+      }
+    }
+
+    // Grammar — the structures carrying the sentence, each explained.
+    if (tutor.grammar.length > 0) {
+      container.addChild(new Text(theme.fg('muted', 'Grammar'), 1, 0))
+      for (const g of tutor.grammar) {
+        container.addChild(
+          new Text(`${theme.fg('accent', g.structure)}  ${theme.fg('dim', g.note)}`, 1, 0)
+        )
+      }
+    }
+
+    return container
+  })
+}
+
+/** Hide the tutor widget (shared widget key with the check). */
+export function hideTutorWidget(ctx: ExtensionContext): void {
+  ctx.ui.setWidget(WIDGET_KEY, undefined)
+}

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   shouldSkipCheck,
-  parseGrammarResult,
+  parseReviewResult,
+  buildReviewPrompt,
   segmentMarkdown,
   cardMarkdown,
   buildSegmentPrompt,
@@ -45,8 +46,11 @@ describe('shouldSkipCheck', () => {
     it('mostly code tokens', () => {
       expect(shouldSkipCheck('const x = foo(bar); y->z; a[i] = {b: 1};')).toBe(true)
     })
-    it('mostly CJK when learning en (<4 whitespace words)', () => {
-      expect(shouldSkipCheck('请帮我修复这个程序里的错误谢谢')).toBe(true)
+    it('short CJK prompt (<4 chars): skipped', () => {
+      expect(shouldSkipCheck('你好吗')).toBe(true)
+    })
+    it('substantial CJK prompt is NOT skipped (reaches the tutor)', () => {
+      expect(shouldSkipCheck('请帮我修复这个程序里的错误谢谢')).toBe(false)
     })
     it('symbols only', () => {
       expect(shouldSkipCheck('=== !== >>> <<< &&& ||| ??? *** !!!')).toBe(true)
@@ -71,28 +75,89 @@ describe('shouldSkipCheck', () => {
   })
 })
 
-describe('parseGrammarResult', () => {
-  it('clean json', () => {
+describe('parseReviewResult', () => {
+  it('check mode: clean json', () => {
     expect(
-      parseGrammarResult(
-        '{"skip": false, "items": [{"wrong":"a","right":"b","reason":"c"}], "rephrase": null}'
+      parseReviewResult(
+        '{"mode": "check", "items": [{"wrong":"a","right":"b","reason":"c"}], "rephrase": null}'
       )
-    ).toEqual({ skip: false, items: [{ wrong: 'a', right: 'b', reason: 'c' }], rephrase: null })
+    ).toEqual({
+      mode: 'check',
+      items: [{ wrong: 'a', right: 'b', reason: 'c' }],
+      rephrase: null
+    })
+  })
+  it('check mode: tolerates a missing "mode" (backward-compatible shape)', () => {
+    expect(parseReviewResult('{"items": [], "rephrase": null}')).toEqual({
+      mode: 'check',
+      items: [],
+      rephrase: null
+    })
+  })
+  it('check mode: trims rephrase and drops empty items', () => {
+    expect(
+      parseReviewResult(
+        '{"mode": "check", "items": [{"wrong": "", "right": "", "reason": ""}], "rephrase": "  "}'
+      )
+    ).toEqual({ mode: 'check', items: [], rephrase: null })
+  })
+  it('tutor mode: parses sentence, words, grammar', () => {
+    expect(
+      parseReviewResult(
+        '{"mode": "tutor", "sentence": "I want to refactor this function.", "words": [{"word": "refactor", "note": "重构"}], "grammar": [{"structure": "want to + infinitive", "note": "表示想要做某事"}]}'
+      )
+    ).toEqual({
+      mode: 'tutor',
+      tutor: {
+        sentence: 'I want to refactor this function.',
+        words: [{ word: 'refactor', note: '重构' }],
+        grammar: [{ structure: 'want to + infinitive', note: '表示想要做某事' }]
+      }
+    })
+  })
+  it('tutor mode: caps words at 5 and grammar at 3', () => {
+    const raw = JSON.stringify({
+      mode: 'tutor',
+      sentence: 'x',
+      words: Array.from({ length: 8 }, (_, i) => ({ word: `w${i}`, note: 'n' })),
+      grammar: Array.from({ length: 5 }, (_, i) => ({ structure: `g${i}`, note: 'n' }))
+    })
+    const r = parseReviewResult(raw)
+    expect(r).toEqual({
+      mode: 'tutor',
+      tutor: {
+        sentence: 'x',
+        words: Array.from({ length: 5 }, (_, i) => ({ word: `w${i}`, note: 'n' })),
+        grammar: Array.from({ length: 3 }, (_, i) => ({ structure: `g${i}`, note: 'n' }))
+      }
+    })
+  })
+  it('tutor mode with no teachable content degrades to skip', () => {
+    expect(
+      parseReviewResult('{"mode": "tutor", "sentence": "", "words": [], "grammar": []}')
+    ).toEqual({ mode: 'skip' })
+  })
+  it('skip mode', () => {
+    expect(parseReviewResult('{"mode": "skip"}')).toEqual({ mode: 'skip' })
+  })
+  it('legacy {"skip": true} (old writing-check shape) maps to skip', () => {
+    expect(parseReviewResult('{"skip": true}')).toEqual({ mode: 'skip' })
   })
   it('fenced json', () => {
-    expect(parseGrammarResult('```json\n{"skip": true}\n```')).toEqual({ skip: true })
+    expect(parseReviewResult('```json\n{"mode": "skip"}\n```')).toEqual({ mode: 'skip' })
   })
   it('json with preamble', () => {
-    expect(parseGrammarResult('Here is the result:\n{"skip": false, "items": []}')).toEqual({
-      skip: false,
-      items: []
+    expect(parseReviewResult('Here is the result:\n{"mode": "check", "items": []}')).toEqual({
+      mode: 'check',
+      items: [],
+      rephrase: null
     })
   })
   it('garbage', () => {
-    expect(parseGrammarResult('I cannot help with that')).toBeUndefined()
+    expect(parseReviewResult('I cannot help with that')).toBeUndefined()
   })
   it('truncated json', () => {
-    expect(parseGrammarResult('{"skip": false, "items": [{"wrong": "a"')).toBeUndefined()
+    expect(parseReviewResult('{"mode": "check", "items": [{"wrong": "a"')).toBeUndefined()
   })
 })
 
@@ -169,6 +234,26 @@ describe('cardMarkdown', () => {
   })
   it('replaces long code with a placeholder', () => {
     expect(card).toContain('*[code block ↑ 23 lines]*')
+  })
+})
+
+describe('buildReviewPrompt', () => {
+  const cfg = { learning: 'en', native: 'zh-CN', enabled: true, auto: false, context: false }
+  const prompt = buildReviewPrompt('some prompt', cfg)
+  it('mentions both modes and the learning language', () => {
+    expect(prompt).toContain('mode "check"')
+    expect(prompt).toContain('mode "tutor"')
+    expect(prompt).toContain('{"mode": "skip"}')
+    expect(prompt).toContain(cfg.learning)
+  })
+  it('wraps the message in <<< >>> delimiters', () => {
+    expect(prompt).toContain('<<<\nsome prompt\n>>>')
+  })
+  it('asks the tutor to teach words, grammar, and the whole sentence in the native language', () => {
+    expect(prompt).toContain('"sentence"')
+    expect(prompt).toContain('"words"')
+    expect(prompt).toContain('"grammar"')
+    expect(prompt).toContain(cfg.native)
   })
 })
 


### PR DESCRIPTION
Closes #12

## What

A sibling of `✏ Writing check`: when the student writes a prompt in their **native** language (they couldn't yet express it in the learning language), `✏ Writing tutor` teaches them how — instead of doing nothing.

A single LLM call inspects each prompt and picks a mode:

- **`check`** — prompt is in the learning language → review spelling/grammar/phrasing (the existing `✏ Writing check` panel).
- **`tutor`** — prompt is in the native language → teach a natural whole-sentence rendering, the key new vocabulary (each explained in the native language — meaning, usage, why this word over a synonym), and the grammatical structures at work (the new `✏ Writing tutor` panel).
- **`skip`** — too short / code / unclear.

The two panels are complementary and never both fire on the same prompt.

## Why

The harder learning moment is the one `Writing check` can't touch: I have a thought but don't know how to say it in the learning language at all — missing the words, the grammar, the whole sentence. Today the only move is to write it in the native language, and then nothing teaches me anything. This turns that moment into a lesson on the one thought I couldn't express.

## How

- `src/core.ts` — unified `buildReviewPrompt` / `parseReviewResult` replace `buildGrammarPrompt` / `parseGrammarResult`; new `TutorWord` / `TutorGrammar` / `TutorResult` / `ReviewResult` types. `shouldSkipCheck` is CJK-aware: it counts CJK text by characters rather than whitespace words, so a substantial native-language prompt reaches the tutor instead of being dropped as "under 4 words". Word notes cap at 5, grammar at 3.
- `src/tutor.ts` (new) — the `✏ Writing tutor` renderer: whole sentence → Words → Grammar.
- `src/grammar.ts` — `registerGrammarCheck` → `registerReview`; one call, dispatches to the check renderer (existing) or the tutor renderer.
- `src/index.ts`, `src/settings.ts`, `language-learn.ts` — wiring; the settings menu label is now "Writing check & tutor".
- `README.md` / `README.zh-CN.md` — bilingual twins, section-for-section.

The prompt deliberately asks for a single idiomatic whole-sentence rendering plus curated notes, not a word-by-word gloss — the aim is teaching expression, not translation.

## Verified

- `npm run check` — clean
- `npm test` — 84 passed (covers `check` / `tutor` / `skip` branches, the ≤5-words / ≤3-grammar caps, CJK skip heuristic, and `buildReviewPrompt` shape)
- `npm run lint` — only a pre-existing `translate.ts` warning unrelated to this change
- `npm run fmt:check` — clean
- Manually installed via symlink (`~/.pi/agent/extensions/pi-language-tutor → local clone`) and exercised in a live pi session; the `✏ Writing tutor` panel renders the sentence + word notes + grammar notes as designed.

## Open questions for the maintainer

1. **Name** — `Writing tutor` vs `Writing lesson` vs a mode badge on `Writing check`. I went with `Writing tutor`; easy to rename.
2. **Depth vs noise** — I capped words at 5 and grammar at 3 to keep the panel scannable like `Writing check`. Tunable in the prompt.
3. **Implementation** — I reused the `Writing check` code path (one call, one widget key, branch on mode) rather than a parallel module, since the dispatch is a single decision. Happy to split into `src/tutor.ts` owning its own `registerTutor` if a separate widget lifecycle is preferred (the renderer is already isolated there).
