### PR TITLE
chore(pkg): bump version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-language-tutor",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-language-tutor",
-			"version": "0.2.0",
+			"version": "0.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-ai": "^0.80.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-language-tutor",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pi extension for learning a foreign language while coding: background writing feedback (spelling, grammar, natural phrasing) on your prompts and bilingual translation of assistant responses",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## What changed

- Bump `package.json` from `0.2.0` to `0.3.0`.
- Keep the root package versions in `package-lock.json` in sync.

## Why

The `v0.3.0` release workflow checked out package metadata that still declared version `0.2.0`. As a result, `npm publish` attempted to republish `0.2.0` and npm rejected it because that version already exists.

This is a metadata-only change; runtime behavior is unchanged.

## Verification

- `npm run check`
- `npm test` — 87 tests passed
- `npm pack --dry-run --json` — produced `pi-language-tutor@0.3.0` with 13 files, 26,934 B packed and 81,657 B unpacked
