### PR TITLE
docs: add npm, CI, license, downloads, and stars badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # pi-language-tutor
 
+[![npm](https://img.shields.io/npm/v/pi-language-tutor)](https://www.npmjs.com/package/pi-language-tutor)
+[![CI](https://img.shields.io/github/actions/workflow/status/mackt/pi-language-tutor/ci.yml?branch=main&label=CI)](https://github.com/mackt/pi-language-tutor/actions/workflows/ci.yml)
+[![license](https://img.shields.io/npm/l/pi-language-tutor)](https://github.com/mackt/pi-language-tutor/blob/main/LICENSE)
+[![downloads](https://img.shields.io/npm/dw/pi-language-tutor)](https://www.npmjs.com/package/pi-language-tutor)
+[![stars](https://img.shields.io/github/stars/mackt/pi-language-tutor)](https://github.com/mackt/pi-language-tutor)
+
 English | [简体中文](README.zh-CN.md)
 
 Learn a foreign language while you code. A [pi](https://pi.dev) extension that reviews your prompts for spelling, grammar, and natural phrasing — with explanations in your native language — teaches you how to express thoughts you couldn't yet say in the learning language, and renders agent replies as bilingual immersive translations.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,11 @@
 # pi-language-tutor
 
+[![npm](https://img.shields.io/npm/v/pi-language-tutor)](https://www.npmjs.com/package/pi-language-tutor)
+[![CI](https://img.shields.io/github/actions/workflow/status/mackt/pi-language-tutor/ci.yml?branch=main&label=CI)](https://github.com/mackt/pi-language-tutor/actions/workflows/ci.yml)
+[![license](https://img.shields.io/npm/l/pi-language-tutor)](https://github.com/mackt/pi-language-tutor/blob/main/LICENSE)
+[![downloads](https://img.shields.io/npm/dw/pi-language-tutor)](https://www.npmjs.com/package/pi-language-tutor)
+[![stars](https://img.shields.io/github/stars/mackt/pi-language-tutor)](https://github.com/mackt/pi-language-tutor)
+
 [English](README.md) | 简体中文
 
 一边 coding 一边学外语。这是一个 [pi](https://pi.dev) 扩展：检查你 prompt 里的拼写和语法并用母语讲解错在哪；当你用母语写下还不会用学习语言表达的句子时，教你怎么说——给出整句地道说法、关键词汇和语法点；还能把 agent 的回复渲染成沉浸式翻译那样的双语对照。


### PR DESCRIPTION
## Summary
- Add shields.io badges to `README.md` and `README.zh-CN.md` (npm version, CI, license, weekly downloads, GitHub stars).
- Keep both READMEs section-aligned; language switch stays under the badge row.

## Test plan
- [ ] Preview both READMEs on GitHub and confirm badges render and link correctly
- [ ] Confirm CI badge points at `ci.yml` on `main`