### PR TITLE
ci: harden validation and publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,15 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 
       - run: npm ci
       - run: npm run check
       - run: npm test
-      # lint / fmt:check land with the oxlint+oxfmt PR (#5); --if-present
-      # keeps this workflow green on branches that predate those scripts.
-      - run: npm run lint --if-present
-      - run: npm run fmt:check --if-present
+      - run: npm run lint
+      - run: npm run fmt:check
+      - run: npm pack --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -22,5 +22,25 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npm test
+      - run: npm run lint
+      - run: npm run fmt:check
+
+      - name: Verify release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            const { version } = JSON.parse(readFileSync("package.json", "utf8"));
+            const expected = "v" + version;
+            if (process.env.RELEASE_TAG !== expected) {
+              throw new Error(
+                "Release tag " + process.env.RELEASE_TAG +
+                " does not match package version " + expected
+              );
+            }
+          '
+
+      - run: npm pack --dry-run
 
       - run: npm publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,11 @@ Development section of README.md — read that first.
 
 ## Verify before pushing
 
-`npm run check` (typecheck) and `npm test` must both pass. When a change
-claims an improvement, put the measured evidence in the commit/PR body
-(e.g. `npm pack --dry-run` sizes, test counts) — not adjectives.
+`npm run check` (typecheck), `npm test`, `npm run lint`, and
+`npm run fmt:check` must all pass. Run `npm run fmt` to apply formatting
+before the final check. When a change claims an improvement, put the measured
+evidence in the commit/PR body (e.g. `npm pack --dry-run` sizes, test counts) —
+not adjectives.
 
 ## Branches, commits, PRs
 


### PR DESCRIPTION
## What changed

- upgrade `actions/checkout` and `actions/setup-node` from v4 to v7 in CI and publishing
- make lint and formatting mandatory, and validate the npm tarball in CI
- make the publish workflow run the same checks, reject release tags that do not match `package.json`, and dry-run the package before publishing
- align `AGENTS.md` with the checks CI actually requires

## Why

The v0.3.0 release previously reached `npm publish` with a tag/package version mismatch. The workflows also still used Node 20-based action releases, and `--if-present` could silently skip required lint or formatting scripts.

## Verification

- `npm run check`
- `npm test` — 104 tests passed
- `npm run lint` — completed with one pre-existing non-blocking warning in `src/translate.ts`
- `npm run fmt:check`
- `npm pack --dry-run --json` — 13 files, 28,688 bytes packed, 88,913 bytes unpacked
- exercised the release guard locally: `v0.3.0` passed and a mismatched `v9.9.9` failed
- parsed both workflow YAML files locally