### PR TITLE
chore(pkg): resolve transitive audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1641,9 +1641,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2259,9 +2259,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",


### PR DESCRIPTION
## What changed

- update the transitive `brace-expansion` lock entry from 5.0.6 to 5.0.8
- update the nested `protobufjs` lock entry from 7.6.4 to 7.6.5

The change is intentionally lockfile-only and limited to the patched versions allowed by the existing parent dependency ranges.

## Why

`npm audit` reported one high-severity and one moderate-severity development dependency finding. Both packages have patched releases available without changing the project's declared dependencies.

## Verification

- `npm ci` — 0 vulnerabilities
- `npm audit --json` — 0 vulnerabilities
- `npm run check`
- `npm test` — 104 tests passed
- `npm run lint` — completed with one pre-existing non-blocking warning in `src/translate.ts`
- `npm run fmt:check`
- `npm pack --dry-run --json` — 13 files, 28,688 bytes packed, 88,913 bytes unpacked