### PR TITLE
chore(pkg): bump version to 0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,20 +33,12 @@ not adjectives.
 
 ## Releases
 
-1. From the latest `main`, create a branch named `chore/bump-version-X.Y.Z`.
-2. Run `npm version minor|patch --no-git-tag-version`, commit only
-   `package.json` and `package-lock.json` as `chore(pkg): bump version to X.Y.Z`,
-   then open and merge the version-bump PR.
-3. Update local `main` to the merged commit, then create and push its annotated
-   tag: `git tag -a vX.Y.Z -m "chore(release): X.Y.Z"` followed by
-   `git push origin vX.Y.Z`.
-4. Run `gh release create vX.Y.Z --verify-tag --generate-notes` — publishing the
+1. Merge PRs into `main`.
+2. `npm version minor|patch -m "chore(release): %s"` (bumps, commits, tags `vX.Y.Z`).
+3. `git push --follow-tags`
+4. `gh release create vX.Y.Z --verify-tag --generate-notes` — publishing the
    GitHub release triggers `.github/workflows/publish.yml`, which publishes
    to npm via OIDC trusted publishing (no tokens).
-
-Do not run `npm version` again after the bump PR is merged; the merged manifest
-already contains the release version, and another minor/patch bump would advance
-it to the next version.
 
 The npm tarball is whitelisted by `files` in package.json; if you add
 runtime files outside `src/`, update it and sanity-check `npm pack --dry-run`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,12 +33,20 @@ not adjectives.
 
 ## Releases
 
-1. Merge PRs into `main`.
-2. `npm version minor|patch -m "chore(release): %s"` (bumps, commits, tags `vX.Y.Z`).
-3. `git push --follow-tags`
-4. `gh release create vX.Y.Z --verify-tag --generate-notes` — publishing the
+1. From the latest `main`, create a branch named `chore/bump-version-X.Y.Z`.
+2. Run `npm version minor|patch --no-git-tag-version`, commit only
+   `package.json` and `package-lock.json` as `chore(pkg): bump version to X.Y.Z`,
+   then open and merge the version-bump PR.
+3. Update local `main` to the merged commit, then create and push its annotated
+   tag: `git tag -a vX.Y.Z -m "chore(release): X.Y.Z"` followed by
+   `git push origin vX.Y.Z`.
+4. Run `gh release create vX.Y.Z --verify-tag --generate-notes` — publishing the
    GitHub release triggers `.github/workflows/publish.yml`, which publishes
    to npm via OIDC trusted publishing (no tokens).
+
+Do not run `npm version` again after the bump PR is merged; the merged manifest
+already contains the release version, and another minor/patch bump would advance
+it to the next version.
 
 The npm tarball is whitelisted by `files` in package.json; if you add
 runtime files outside `src/`, update it and sanity-check `npm pack --dry-run`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-language-tutor",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-language-tutor",
-			"version": "0.3.0",
+			"version": "0.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"glimpseui": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-language-tutor",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pi extension for learning a foreign language while coding: background writing feedback (spelling, grammar, natural phrasing) on your prompts and bilingual translation of assistant responses",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bump the package version from `0.3.0` to `0.4.0` for the minor release that includes FSRS flashcard review.

This PR changes only the version metadata in `package.json` and `package-lock.json`, keeping the package version and release tag contract aligned before publishing. The corresponding release-procedure documentation is isolated in #23 and should merge first.

## Verification

- `npm audit` — 0 vulnerabilities
- `npm run check` — passed
- `npm test` — 131 tests passed across 2 files
- `npm run lint` — 0 errors; 2 existing warnings
- `npm run fmt:check` — 32 files checked
- `npm pack --dry-run --json` — `pi-language-tutor@0.4.0`, 18 files, 37,513 B packed / 127,612 B unpacked

## Release follow-up

After #23 and this PR are merged, update local `main`, then run:

```sh
git tag -a v0.4.0 -m "chore(release): 0.4.0"
git push origin v0.4.0
gh release create v0.4.0 --verify-tag --generate-notes
```

Publishing the GitHub Release triggers the existing OIDC npm publish workflow. Do not run `npm version minor` again after merging this PR; that would advance the manifest to `0.5.0`.
