### PR TITLE
docs: align release workflow with version bump PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,10 @@ not adjectives.
 ## Releases
 
 1. From the latest `main`, create a branch named `chore/bump-version-X.Y.Z`.
-2. Run `npm version minor|patch --no-git-tag-version`, commit only
-   `package.json` and `package-lock.json` as `chore(pkg): bump version to X.Y.Z`,
-   then open and merge the version-bump PR.
+2. Run either `npm version minor --no-git-tag-version` or
+   `npm version patch --no-git-tag-version`. Commit only `package.json` and
+   `package-lock.json` as `chore(pkg): bump version to X.Y.Z`, then open and
+   merge the version-bump PR.
 3. Update local `main` to the merged commit, then create and push its annotated
    tag: `git tag -a vX.Y.Z -m "chore(release): X.Y.Z"` followed by
    `git push origin vX.Y.Z`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,12 +33,20 @@ not adjectives.
 
 ## Releases
 
-1. Merge PRs into `main`.
-2. `npm version minor|patch -m "chore(release): %s"` (bumps, commits, tags `vX.Y.Z`).
-3. `git push --follow-tags`
-4. `gh release create vX.Y.Z --verify-tag --generate-notes` — publishing the
+1. From the latest `main`, create a branch named `chore/bump-version-X.Y.Z`.
+2. Run `npm version minor|patch --no-git-tag-version`, commit only
+   `package.json` and `package-lock.json` as `chore(pkg): bump version to X.Y.Z`,
+   then open and merge the version-bump PR.
+3. Update local `main` to the merged commit, then create and push its annotated
+   tag: `git tag -a vX.Y.Z -m "chore(release): X.Y.Z"` followed by
+   `git push origin vX.Y.Z`.
+4. Run `gh release create vX.Y.Z --verify-tag --generate-notes` — publishing the
    GitHub release triggers `.github/workflows/publish.yml`, which publishes
    to npm via OIDC trusted publishing (no tokens).
+
+Do not run `npm version` again after the bump PR is merged; the merged manifest
+already contains the release version, and another minor/patch bump would advance
+it to the next version.
 
 The npm tarball is whitelisted by `files` in package.json; if you add
 runtime files outside `src/`, update it and sanity-check `npm pack --dry-run`.


### PR DESCRIPTION
## Summary

Align the documented release workflow with branch protection and focused version-bump PRs.

- Bump `package.json` and `package-lock.json` on a dedicated branch with `npm version --no-git-tag-version`.
- Merge the version-bump PR before tagging.
- Create and push the annotated `vX.Y.Z` tag from the merged `main` commit.
- Do not run `npm version` again after merge, which would advance to the next version.

This documentation change is intentionally separate from #22 so the `chore(pkg)` release commit remains limited to the two manifest files.

## Verification

- `npm audit` — 0 vulnerabilities
- `npm run check` — passed
- `npm test` — 131 tests passed across 2 files
- `npm run lint` — 0 errors; 2 existing warnings
- `npm run fmt:check` — 32 files checked
- `npm pack --dry-run --json` — 18 files, 37,514 B packed / 127,612 B unpacked
