### PR TITLE
docs(readme): remove logo and demo GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/logo.png" width="96" height="96" alt="pi-language-tutor logo" />
-</p>
-
 # pi-language-tutor
 
 <p align="center">
@@ -19,10 +15,6 @@
 
 <p align="center">
   English · <a href="README.zh-CN.md">简体中文</a>
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/demo.gif" width="720" alt="Demo: Writing check, Writing tutor, and bilingual translation panels" />
 </p>
 
 ## Install

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/logo.png" width="96" height="96" alt="pi-language-tutor logo" />
-</p>
-
 # pi-language-tutor
 
 <p align="center">
@@ -19,10 +15,6 @@
 
 <p align="center">
   <a href="README.md">English</a> · 简体中文
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/mackt/pi-language-tutor/main/docs/demo.gif" width="720" alt="演示：Writing check、Writing tutor 与双语翻译面板" />
 </p>
 
 ## 安装


### PR DESCRIPTION
## What changed

- Remove the logo from the top of both README files.
- Remove the initial demo GIF from both README files.
- Keep the English and Chinese README structures synchronized.

## Why

The logo and opening animation are no longer wanted in the README presentation. The underlying image files remain available in the repository.

## Verification

- `npx oxfmt --check README.md README.zh-CN.md`
- `git diff --check`