### PR TITLE
chore(pkg): bump version to 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-language-tutor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-language-tutor",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "glimpseui": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-language-tutor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pi extension for learning a foreign language while coding: background writing feedback (spelling, grammar, natural phrasing) on your prompts and bilingual translation of assistant responses",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## What

Bump package version 0.4.0 → 0.4.1 via `npm version patch --no-git-tag-version`, in preparation for the 0.4.1 release.

## Verification

Only `package.json` and `package-lock.json` changed; both now read `0.4.1`.